### PR TITLE
Project Local Commands, Better Windows Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Unreleased
 
+## Added
+
+- Project-local commands now discover the nearest enclosing `nupackage.toml` by walking up from the current working directory, so commands like `qv run amazing.nu` work from subdirectories of a Quiver project.
+
+## Fixed
+
+- Improved Windows compatibility for Quiver-managed Nushell binaries by consistently using the platform-specific `.nu-env/bin/nu` path (`nu.exe` on Windows) across `qvx`, generated project env files, plugin registration, and editor LSP configs.
+- Global Quiver config and lockfile paths now use the platform config directory on windows and `~/.config` on macOS/linux.
+- `qv lsp` now fails clearly on Windows when invoked without explicit editor names, instead of attempting to use the Unix-only interactive picker (hopefully switch to ratatui for this at some point).
+
 # Version 0.5.1 (2026-04-22)
 
 ## Added

--- a/src/config.rs
+++ b/src/config.rs
@@ -276,19 +276,30 @@ impl GlobalConfig {
     }
 }
 
-/// Returns the global config directory: `~/.config/quiver/`.
+/// Returns the global config directory.
 pub fn global_config_dir() -> Result<PathBuf> {
-    let home = dirs::home_dir()
-        .ok_or_else(|| QuiverError::Config("could not determine home directory".to_string()))?;
-    Ok(home.join(".config").join("quiver"))
+    #[cfg(windows)]
+    {
+        let config = dirs::config_dir().ok_or_else(|| {
+            QuiverError::Config("could not determine config directory".to_string())
+        })?;
+        return Ok(config.join("quiver"));
+    }
+
+    #[cfg(not(windows))]
+    {
+        let home = dirs::home_dir()
+            .ok_or_else(|| QuiverError::Config("could not determine home directory".to_string()))?;
+        Ok(home.join(".config").join("quiver"))
+    }
 }
 
-/// Returns the path to the global config file: `~/.config/quiver/config.toml`.
+/// Returns the path to the global config file.
 pub fn global_config_path() -> Result<PathBuf> {
     Ok(global_config_dir()?.join("config.toml"))
 }
 
-/// Returns the path to the global lockfile: `~/.config/quiver/config.lock`.
+/// Returns the path to the global lockfile.
 pub fn global_lock_path() -> Result<PathBuf> {
     Ok(global_config_dir()?.join("config.lock"))
 }
@@ -452,15 +463,19 @@ mod tests {
 
     #[test]
     fn config_dir_paths() {
-        // These should not error on any platform with a home directory
+        #[cfg(windows)]
+        let expected_dir = dirs::config_dir().unwrap().join("quiver");
+        #[cfg(not(windows))]
+        let expected_dir = dirs::home_dir().unwrap().join(".config").join("quiver");
+
         let dir = global_config_dir().unwrap();
-        assert!(dir.ends_with("quiver"));
+        assert_eq!(dir, expected_dir);
 
         let path = global_config_path().unwrap();
-        assert!(path.ends_with("quiver/config.toml"));
+        assert_eq!(path, expected_dir.join("config.toml"));
 
         let lock = global_lock_path().unwrap();
-        assert!(lock.ends_with("quiver/config.lock"));
+        assert_eq!(lock, expected_dir.join("config.lock"));
     }
 
     #[test]

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -942,7 +942,7 @@ fn verify_frozen_checksum(
 pub fn write_activate_overlay(nu_env_dir: &Path, project_dir: &Path) -> Result<()> {
     std::fs::create_dir_all(nu_env_dir)?;
 
-    let nu_bin = nu_env_dir.join(BIN_SUBDIR).join("nu");
+    let nu_bin = nu_env_binary_path(nu_env_dir);
     let env_bin_dir = nu_env_dir.join(BIN_SUBDIR);
     let config_nu = nu_env_dir.join("config.nu");
     let plugin_config = nu_env_dir.join("plugins.msgpackz");
@@ -986,7 +986,7 @@ pub fn write_config_nu(nu_env_dir: &Path, modules_dir: &Path) -> Result<()> {
 
     let modules_literal = nu_string_literal(modules_dir);
     let bin_literal = nu_string_literal(&nu_env_dir.join(BIN_SUBDIR));
-    let nu_bin_literal = nu_string_literal(&nu_env_dir.join(BIN_SUBDIR).join("nu"));
+    let nu_bin_literal = nu_string_literal(&nu_env_binary_path(nu_env_dir));
     let plugin_config_literal = nu_string_literal(&nu_env_dir.join("plugins.msgpackz"));
     let config_literal = nu_string_literal(&nu_env_dir.join("config.nu"));
 
@@ -1056,19 +1056,22 @@ fn create_nu_symlink_with_policy(
     let bin_dir = nu_env_dir.join(BIN_SUBDIR);
     std::fs::create_dir_all(&bin_dir)?;
 
-    let symlink_path = bin_dir.join("nu");
+    let symlink_path = nu_env_binary_path(nu_env_dir);
+    let env_binary_name = nu_env_binary_name();
 
     let nu_path = match resolve_nu_binary_for_requirement(nu_version_req, security_policy)? {
         Some(path) => path,
         None if nu_version_req.is_none() => {
-            ui::warn("could not find 'nu' in PATH; skipping .nu-env/bin/nu symlink.");
+            ui::warn(format!(
+                "could not find 'nu' in PATH; skipping .nu-env/bin/{env_binary_name} link."
+            ));
             return Ok(());
         }
         None => {
             let required = nu_version_req.unwrap_or_default();
             let installs = config::installs_nu_versions_dir()?;
             return Err(crate::error::QuiverError::Other(format!(
-                "could not find a Nushell binary matching '{required}' in PATH or {}; install it under {}/<version>/nu",
+                "could not find a Nushell binary matching '{required}' in PATH or {}; install it under {}/<version>/bin/{env_binary_name}",
                 installs.display(),
                 installs.display()
             )));
@@ -1076,9 +1079,20 @@ fn create_nu_symlink_with_policy(
     };
 
     if ensure_symlink_or_file(&symlink_path, &nu_path)? {
-        ui::success(format!("Linked .nu-env/bin/nu -> {}", nu_path.display()));
+        ui::success(format!(
+            "Linked .nu-env/bin/{env_binary_name} -> {}",
+            nu_path.display()
+        ));
     }
     Ok(())
+}
+
+pub(crate) fn nu_env_binary_name() -> &'static str {
+    if cfg!(windows) { "nu.exe" } else { "nu" }
+}
+
+pub(crate) fn nu_env_binary_path(nu_env_dir: &Path) -> PathBuf {
+    nu_env_dir.join(BIN_SUBDIR).join(nu_env_binary_name())
 }
 
 fn resolve_nu_binary_for_requirement(
@@ -2602,7 +2616,7 @@ fn sync_plugin_registry(nu_env_dir: &Path, plugins: &[ResolvedPlugin]) -> Result
         return Ok(());
     }
 
-    let nu_bin = bin_dir.join("nu");
+    let nu_bin = nu_env_binary_path(nu_env_dir);
     if !nu_bin.exists() {
         return Err(crate::error::QuiverError::Other(format!(
             "cannot register plugins because '{}' was not found",
@@ -3816,7 +3830,7 @@ mod tests {
         let guard = EnvVarGuard::set("QUIVER_INSTALLS_ROOT", &store_root);
         let version_dir = store_root.join("nu_versions").join(version).join("bin");
         std::fs::create_dir_all(&version_dir).unwrap();
-        std::fs::write(version_dir.join("nu"), "nu").unwrap();
+        std::fs::write(version_dir.join(nu_env_binary_name()), "nu").unwrap();
         (store_root, guard)
     }
 
@@ -3858,6 +3872,7 @@ mod tests {
     fn writes_activate_overlay() {
         let project_dir = make_temp_dir("activate_overlay");
         let nu_env_dir = project_dir.join(".nu-env");
+        let expected_nu_path = format!(".nu-env/bin/{}", nu_env_binary_name());
 
         write_activate_overlay(&nu_env_dir, &project_dir).unwrap();
 
@@ -3866,7 +3881,7 @@ mod tests {
         assert!(activate.contains("source-env"));
         assert!(activate.contains("export alias nu = ^"));
         assert!(activate.contains("^"));
-        assert!(activate.contains(".nu-env/bin/nu"));
+        assert!(activate.contains(&expected_nu_path));
         assert!(activate.contains("--config"));
         assert!(activate.contains(".nu-env/config.nu"));
         assert!(activate.contains("use std [ 'path add' ]"));
@@ -4803,11 +4818,12 @@ sha256 = "aaa"
             .join("255.255.255")
             .join("bin");
         std::fs::create_dir_all(&version_dir).unwrap();
-        std::fs::write(version_dir.join("nu"), "nu").unwrap();
+        let installed_nu = version_dir.join(nu_env_binary_name());
+        std::fs::write(&installed_nu, "nu").unwrap();
 
         create_nu_symlink(&nu_env_dir, Some("=255.255.255")).unwrap();
 
-        let symlink_path = nu_env_dir.join("bin").join("nu");
+        let symlink_path = nu_env_binary_path(&nu_env_dir);
         assert!(symlink_path.exists());
         assert!(
             symlink_path
@@ -4817,7 +4833,7 @@ sha256 = "aaa"
                 .is_symlink()
         );
         let target = std::fs::read_link(&symlink_path).unwrap();
-        assert_eq!(target, version_dir.join("nu"));
+        assert_eq!(target, installed_nu);
 
         let _ = std::fs::remove_dir_all(nu_env_dir);
         let _ = std::fs::remove_dir_all(store_root);
@@ -4833,15 +4849,16 @@ sha256 = "aaa"
             .join("255.255.255")
             .join("bin");
         std::fs::create_dir_all(&version_dir).unwrap();
-        std::fs::write(version_dir.join("nu"), "nu").unwrap();
+        let installed_nu = version_dir.join(nu_env_binary_name());
+        std::fs::write(&installed_nu, "nu").unwrap();
         let bin_dir = nu_env_dir.join("bin");
         std::fs::create_dir_all(&bin_dir).unwrap();
         // Create a dummy file where the symlink would go
-        std::fs::write(bin_dir.join("nu"), "dummy").unwrap();
+        std::fs::write(nu_env_binary_path(&nu_env_dir), "dummy").unwrap();
 
         create_nu_symlink(&nu_env_dir, Some("=255.255.255")).unwrap();
 
-        let symlink_path = bin_dir.join("nu");
+        let symlink_path = nu_env_binary_path(&nu_env_dir);
         assert!(symlink_path.exists());
         assert!(
             symlink_path
@@ -4851,7 +4868,7 @@ sha256 = "aaa"
                 .is_symlink()
         );
         let target = std::fs::read_link(&symlink_path).unwrap();
-        assert_eq!(target, version_dir.join("nu"));
+        assert_eq!(target, installed_nu);
 
         let _ = std::fs::remove_dir_all(nu_env_dir);
         let _ = std::fs::remove_dir_all(store_root);
@@ -4913,7 +4930,7 @@ sha256 = "aaa"
     #[test]
     fn detect_nu_path_prefers_quiver_nu_bin_override() {
         let override_dir = make_temp_dir("nu_bin_override");
-        let override_path = override_dir.join("nu");
+        let override_path = override_dir.join(nu_env_binary_name());
         std::fs::write(&override_path, "nu").unwrap();
         let _guard = EnvVarGuard::set_os(QUIVER_NU_BIN_ENV, override_path.clone().into_os_string());
 
@@ -4929,7 +4946,7 @@ sha256 = "aaa"
 
         create_nu_symlink(&nu_env_dir, Some("=255.255.255")).unwrap();
 
-        assert!(!nu_env_dir.join("bin").join("nu").exists());
+        assert!(!nu_env_binary_path(&nu_env_dir).exists());
 
         let _ = std::fs::remove_dir_all(nu_env_dir);
     }
@@ -5143,7 +5160,7 @@ nu_plugin_inc = { git = "https://github.com/nushell/nu_plugin_inc", tag = "v0.91
         let nested = extracted.join("nu-0.110.0");
         std::fs::create_dir_all(&nested).unwrap();
 
-        std::fs::write(nested.join("nu"), "nu").unwrap();
+        std::fs::write(nested.join(nu_env_binary_name()), "nu").unwrap();
         std::fs::write(nested.join("README.txt"), "readme").unwrap();
         let formats = plugin_test_name("nu_plugin_formats");
         let query = plugin_test_name("nu_plugin_query");
@@ -5206,7 +5223,7 @@ nu_plugin_inc = { git = "https://github.com/nushell/nu_plugin_inc", tag = "v0.91
         let root = make_temp_dir("core_plugin_same_dir");
         let nu_dir = root.join("usr").join("local").join("bin");
         std::fs::create_dir_all(&nu_dir).unwrap();
-        let nu_path = nu_dir.join("nu");
+        let nu_path = nu_dir.join(nu_env_binary_name());
         std::fs::write(&nu_path, "nu").unwrap();
         let plugin_name = plugin_test_name("nu_plugin_query");
         let plugin_path = nu_dir.join(&plugin_name);
@@ -5224,7 +5241,7 @@ nu_plugin_inc = { git = "https://github.com/nushell/nu_plugin_inc", tag = "v0.91
         let root = make_temp_dir("core_plugin_quiver_store");
         let version_bin = root.join("nu_versions").join("0.110.0").join("bin");
         std::fs::create_dir_all(&version_bin).unwrap();
-        let nu_path = version_bin.join("nu");
+        let nu_path = version_bin.join(nu_env_binary_name());
         std::fs::write(&nu_path, "nu").unwrap();
         let plugin_name = plugin_test_name("nu_plugin_polars");
         let plugins_dir = root.join("nu_versions").join("0.110.0").join("plugins");

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,10 +57,14 @@ fn run(command: Commands) -> Result<()> {
             if global {
                 cmd_install_global(frozen, allow_unsigned, no_build_fallback)
             } else {
-                cmd_install(&cwd, frozen, allow_unsigned, no_build_fallback)
+                let project_dir = require_project_dir(&cwd)?;
+                cmd_install(&project_dir, frozen, allow_unsigned, no_build_fallback)
             }
         }
-        Commands::Update => cmd_update(&cwd),
+        Commands::Update => {
+            let project_dir = require_project_dir(&cwd)?;
+            cmd_update(&project_dir)
+        }
         Commands::Add {
             global,
             url,
@@ -71,7 +75,8 @@ fn run(command: Commands) -> Result<()> {
             if global {
                 cmd_add_global(url, tag, rev, branch)
             } else {
-                cmd_add(&cwd, url, tag, rev, branch)
+                let project_dir = require_project_dir(&cwd)?;
+                cmd_add(&project_dir, url, tag, rev, branch)
             }
         }
         Commands::AddPlugin {
@@ -85,20 +90,25 @@ fn run(command: Commands) -> Result<()> {
             if global {
                 cmd_add_global_plugin(url, tag, rev, branch, bin)
             } else {
-                cmd_add_plugin(&cwd, url, tag, rev, branch, bin)
+                let project_dir = require_project_dir(&cwd)?;
+                cmd_add_plugin(&project_dir, url, tag, rev, branch, bin)
             }
         }
         Commands::Remove { global, name } => {
             if global {
                 cmd_remove_global(name)
             } else {
-                cmd_remove(&cwd, name)
+                let project_dir = require_project_dir(&cwd)?;
+                cmd_remove(&project_dir, name)
             }
         }
         Commands::List => cmd_list(&cwd),
         Commands::Version => cmd_version(),
         Commands::Hook => cmd_hook(),
-        Commands::Lsp { editor } => cmd_lsp(&cwd, editor),
+        Commands::Lsp { editor } => {
+            let project_dir = require_project_dir(&cwd)?;
+            cmd_lsp(&project_dir, editor)
+        }
         Commands::Run { command } => cmd_run(&cwd, command),
         Commands::Qvx {
             tag,
@@ -110,6 +120,11 @@ fn run(command: Commands) -> Result<()> {
             args,
         } => cmd_qvx(&cwd, source, tag, rev, branch, nu_version, command, args),
     }
+}
+
+fn require_project_dir(start: &Path) -> Result<PathBuf> {
+    Manifest::find_project_dir(start)
+        .ok_or_else(|| error::QuiverError::NoManifest(start.to_path_buf()))
 }
 
 fn cmd_init(
@@ -658,19 +673,16 @@ fn cmd_run(cwd: &Path, command: Vec<String>) -> Result<()> {
         ));
     }
 
-    if !cwd.join("nupackage.toml").exists() {
-        return Err(error::QuiverError::NoManifest(cwd.to_path_buf()));
-    }
-
-    let manifest = Manifest::from_dir(cwd)?;
-    let config_path = cwd.join(".nu-env").join("config.nu");
-    let plugin_config_path = cwd.join(".nu-env").join("plugins.msgpackz");
+    let project_dir = require_project_dir(cwd)?;
+    let manifest = Manifest::from_dir(&project_dir)?;
+    let config_path = project_dir.join(".nu-env").join("config.nu");
+    let plugin_config_path = project_dir.join(".nu-env").join("plugins.msgpackz");
     let needs_install = !config_path.exists()
         || (!manifest.dependencies.plugins.is_empty() && !plugin_config_path.exists());
 
     if needs_install {
         eprintln!("Project environment is incomplete; running install first...");
-        installer::install_with_options(cwd, false, false, false, false)?;
+        installer::install_with_options(&project_dir, false, false, false, false)?;
     }
 
     if !config_path.exists() {
@@ -1266,9 +1278,9 @@ fn write_zed_lsp_config(project_dir: &Path) -> Result<()> {
 }
 
 fn cmd_list(cwd: &Path) -> Result<()> {
-    if cwd.join("nupackage.toml").exists() {
-        let modules_dir = cwd.join(".nu-env").join("modules");
-        let bin_dir = cwd.join(".nu-env").join("bin");
+    if let Some(project_dir) = Manifest::find_project_dir(cwd) {
+        let modules_dir = project_dir.join(".nu-env").join("modules");
+        let bin_dir = project_dir.join(".nu-env").join("bin");
         let modules = list_installed_module_names(&modules_dir)?;
         let plugins = list_installed_plugin_names(&bin_dir)?;
 
@@ -2097,6 +2109,30 @@ sha256 = "bbb"
         assert!(matches!(err, error::QuiverError::NoManifest(_)));
 
         let _ = std::fs::remove_dir_all(cwd);
+    }
+
+    #[test]
+    fn cmd_run_discovers_project_from_subdirectory() {
+        let root = make_temp_dir("run_from_subdir");
+        let nested = root.join("examples").join("demo");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(
+            root.join("nupackage.toml"),
+            "[package]\nname = \"demo\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        std::fs::create_dir_all(root.join(".nu-env")).unwrap();
+        std::fs::write(root.join(".nu-env").join("config.nu"), "").unwrap();
+        std::fs::write(nested.join("check-cwd.sh"), "test -f local.txt\n").unwrap();
+        std::fs::write(nested.join("local.txt"), "ok\n").unwrap();
+
+        cmd_run(
+            &nested,
+            vec!["sh".to_string(), "./check-cwd.sh".to_string()],
+        )
+        .unwrap();
+
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -741,9 +741,7 @@ fn cmd_qvx(
     let wrapper_path = nu_env_dir.join("qvx-run.nu");
     let wrapper = build_qvx_wrapper(&pkg_name, &command, &args)?;
     std::fs::write(&wrapper_path, wrapper)?;
-    let nu_bin = nu_env_dir
-        .join("bin")
-        .join(if cfg!(windows) { "nu.exe" } else { "nu" });
+    let nu_bin = installer::nu_env_binary_path(&nu_env_dir);
     let nu_command = if nu_bin.symlink_metadata().is_ok() {
         nu_bin.as_path()
     } else {
@@ -993,7 +991,7 @@ fn resolve_run_invocation(
     let config = config_path.to_string_lossy().to_string();
     let plugin_config = plugin_config_path.to_string_lossy().to_string();
 
-    if executable == "nu" {
+    if is_nushell_command_name(&executable) {
         if !args.iter().any(|arg| arg == "--plugin-config") {
             args.insert(0, plugin_config);
             args.insert(0, "--plugin-config".to_string());
@@ -1018,6 +1016,10 @@ fn resolve_run_invocation(
     }
 
     (executable, args)
+}
+
+fn is_nushell_command_name(executable: &str) -> bool {
+    executable.eq_ignore_ascii_case("nu") || executable.eq_ignore_ascii_case("nu.exe")
 }
 
 fn is_nushell_script_command(executable: &str, cwd: &Path) -> bool {
@@ -1111,121 +1113,132 @@ fn cmd_lsp(cwd: &Path, editors: Vec<String>) -> Result<()> {
 
 /// Interactive checkbox picker rendered to stderr.
 fn pick_editors(options: &[&str]) -> Result<Vec<String>> {
-    use std::io::Read;
+    #[cfg(windows)]
+    {
+        let supported = options.join(", ");
+        return Err(error::QuiverError::Other(format!(
+            "interactive editor selection is not supported on Windows; pass one or more editors explicitly: {supported}"
+        )));
+    }
 
-    let mut selected = vec![false; options.len()];
-    let mut cursor = 0usize;
+    #[cfg(not(windows))]
+    {
+        use std::io::Read;
 
-    // Save terminal state and enable raw mode
-    let stdin = io::stdin();
-    let mut stderr = io::stderr();
+        let mut selected = vec![false; options.len()];
+        let mut cursor = 0usize;
 
-    // Set raw mode via stty
-    let _ = Command::new("stty")
-        .arg("raw")
-        .arg("-echo")
-        .stdin(std::process::Stdio::inherit())
-        .status();
+        // Save terminal state and enable raw mode
+        let stdin = io::stdin();
+        let mut stderr = io::stderr();
 
-    let render = |selected: &[bool], cursor: usize, out: &mut io::Stderr| -> io::Result<()> {
-        // Move to start and clear
-        write!(out, "\r\x1b[J")?;
-        write!(
-            out,
-            "Select editors to configure (space=toggle, j/k=move, enter=confirm):\r\n"
-        )?;
-        for (i, option) in options.iter().enumerate() {
-            let check = if selected[i] { "x" } else { " " };
-            let prefix = if i == cursor { "> " } else { "  " };
-            write!(out, "{prefix}[{check}] {option}\r\n")?;
-        }
-        out.flush()
-    };
+        // Set raw mode via stty
+        let _ = Command::new("stty")
+            .arg("raw")
+            .arg("-echo")
+            .stdin(std::process::Stdio::inherit())
+            .status();
 
-    render(&selected, cursor, &mut stderr)?;
+        let render = |selected: &[bool], cursor: usize, out: &mut io::Stderr| -> io::Result<()> {
+            // Move to start and clear
+            write!(out, "\r\x1b[J")?;
+            write!(
+                out,
+                "Select editors to configure (space=toggle, j/k=move, enter=confirm):\r\n"
+            )?;
+            for (i, option) in options.iter().enumerate() {
+                let check = if selected[i] { "x" } else { " " };
+                let prefix = if i == cursor { "> " } else { "  " };
+                write!(out, "{prefix}[{check}] {option}\r\n")?;
+            }
+            out.flush()
+        };
 
-    let result = (|| -> Result<Vec<String>> {
-        let mut bytes = stdin.lock().bytes();
-        loop {
-            let b = match bytes.next() {
-                Some(Ok(b)) => b,
-                _ => break,
-            };
+        render(&selected, cursor, &mut stderr)?;
 
-            match b {
-                b'\n' | b'\r' => {
-                    // Enter — confirm
-                    break;
-                }
-                b' ' => {
-                    selected[cursor] = !selected[cursor];
-                }
-                b'j' => {
-                    if cursor + 1 < options.len() {
-                        cursor += 1;
+        let result = (|| -> Result<Vec<String>> {
+            let mut bytes = stdin.lock().bytes();
+            loop {
+                let b = match bytes.next() {
+                    Some(Ok(b)) => b,
+                    _ => break,
+                };
+
+                match b {
+                    b'\n' | b'\r' => {
+                        // Enter — confirm
+                        break;
                     }
-                }
-                b'k' => {
-                    if cursor > 0 {
-                        cursor -= 1;
+                    b' ' => {
+                        selected[cursor] = !selected[cursor];
                     }
-                }
-                b'q' | 3 => {
-                    // q or Ctrl-C — abort
-                    let _ = Command::new("stty")
-                        .arg("sane")
-                        .stdin(std::process::Stdio::inherit())
-                        .status();
-                    write!(stderr, "\r\x1b[J")?;
-                    stderr.flush()?;
-                    std::process::exit(0);
-                }
-                27 => {
-                    // Escape sequence (arrow keys)
-                    let next = bytes.next();
-                    if let Some(Ok(b'[')) = next {
-                        if let Some(Ok(arrow)) = bytes.next() {
-                            match arrow {
-                                b'A' => {
-                                    if cursor > 0 {
-                                        cursor -= 1;
-                                    }
-                                } // Up
-                                b'B' => {
-                                    if cursor + 1 < options.len() {
-                                        cursor += 1;
-                                    }
-                                } // Down
-                                _ => {}
+                    b'j' => {
+                        if cursor + 1 < options.len() {
+                            cursor += 1;
+                        }
+                    }
+                    b'k' => {
+                        if cursor > 0 {
+                            cursor -= 1;
+                        }
+                    }
+                    b'q' | 3 => {
+                        // q or Ctrl-C — abort
+                        let _ = Command::new("stty")
+                            .arg("sane")
+                            .stdin(std::process::Stdio::inherit())
+                            .status();
+                        write!(stderr, "\r\x1b[J")?;
+                        stderr.flush()?;
+                        std::process::exit(0);
+                    }
+                    27 => {
+                        // Escape sequence (arrow keys)
+                        let next = bytes.next();
+                        if let Some(Ok(b'[')) = next {
+                            if let Some(Ok(arrow)) = bytes.next() {
+                                match arrow {
+                                    b'A' => {
+                                        if cursor > 0 {
+                                            cursor -= 1;
+                                        }
+                                    } // Up
+                                    b'B' => {
+                                        if cursor + 1 < options.len() {
+                                            cursor += 1;
+                                        }
+                                    } // Down
+                                    _ => {}
+                                }
                             }
                         }
                     }
+                    _ => {}
                 }
-                _ => {}
+
+                // Move cursor up to re-render
+                let lines_to_move = options.len() + 1; // +1 for the header line
+                write!(stderr, "\x1b[{}A", lines_to_move)?;
+                render(&selected, cursor, &mut stderr)?;
             }
 
-            // Move cursor up to re-render
-            let lines_to_move = options.len() + 1; // +1 for the header line
-            write!(stderr, "\x1b[{}A", lines_to_move)?;
-            render(&selected, cursor, &mut stderr)?;
-        }
+            Ok(options
+                .iter()
+                .zip(selected.iter())
+                .filter_map(|(name, &sel)| if sel { Some(name.to_string()) } else { None })
+                .collect())
+        })();
 
-        Ok(options
-            .iter()
-            .zip(selected.iter())
-            .filter_map(|(name, &sel)| if sel { Some(name.to_string()) } else { None })
-            .collect())
-    })();
+        // Restore terminal
+        let _ = Command::new("stty")
+            .arg("sane")
+            .stdin(std::process::Stdio::inherit())
+            .status();
+        write!(stderr, "\r\x1b[J")?;
+        stderr.flush()?;
 
-    // Restore terminal
-    let _ = Command::new("stty")
-        .arg("sane")
-        .stdin(std::process::Stdio::inherit())
-        .status();
-    write!(stderr, "\r\x1b[J")?;
-    stderr.flush()?;
-
-    result
+        result
+    }
 }
 
 fn write_helix_lsp_config(project_dir: &Path) -> Result<()> {
@@ -1234,7 +1247,7 @@ fn write_helix_lsp_config(project_dir: &Path) -> Result<()> {
 
     let config_path = helix_dir.join("languages.toml");
     let config = r#"[language-server.nu-lsp]
-command = ".nu-env/bin/nu"
+command = "__QUIVER_NU_BIN__"
 args = [
   "--config",
   ".nu-env/config.nu",
@@ -1242,7 +1255,11 @@ args = [
   ".nu-env/plugins.msgpackz",
   "--lsp"
 ]
-"#;
+"#
+    .replace(
+        "__QUIVER_NU_BIN__",
+        &format!(".nu-env/bin/{}", installer::nu_env_binary_name()),
+    );
 
     std::fs::write(&config_path, config)?;
     eprintln!("Generated .helix/languages.toml");
@@ -1258,7 +1275,7 @@ fn write_zed_lsp_config(project_dir: &Path) -> Result<()> {
   "lsp": {
     "nu": {
       "binary": {
-        "path": ".nu-env/bin/nu",
+        "path": "__QUIVER_NU_BIN__",
         "arguments": [
           "--config",
           ".nu-env/config.nu",
@@ -1270,7 +1287,11 @@ fn write_zed_lsp_config(project_dir: &Path) -> Result<()> {
     }
   }
 }
-"#;
+"#
+    .replace(
+        "__QUIVER_NU_BIN__",
+        &format!(".nu-env/bin/{}", installer::nu_env_binary_name()),
+    );
 
     std::fs::write(&config_path, config)?;
     eprintln!("Generated .zed/settings.json");
@@ -1682,7 +1703,11 @@ mod tests {
         let guard = EnvVarGuard::set("QUIVER_INSTALLS_ROOT", &store_root);
         let version_dir = store_root.join("nu_versions").join(version).join("bin");
         std::fs::create_dir_all(&version_dir).unwrap();
-        std::fs::write(version_dir.join("nu"), "nu").unwrap();
+        std::fs::write(
+            version_dir.join(crate::installer::nu_env_binary_name()),
+            "nu",
+        )
+        .unwrap();
         (store_root, guard)
     }
 
@@ -1954,7 +1979,11 @@ mod tests {
         let bin_dir = make_temp_dir("list_plugins");
         std::fs::write(bin_dir.join("nu_plugin_query"), "binary").unwrap();
         std::fs::write(bin_dir.join("nu_plugin_polars"), "binary").unwrap();
-        std::fs::write(bin_dir.join("nu"), "binary").unwrap(); // should be excluded
+        std::fs::write(
+            bin_dir.join(crate::installer::nu_env_binary_name()),
+            "binary",
+        )
+        .unwrap(); // should be excluded
         std::fs::write(bin_dir.join("other_file"), "binary").unwrap(); // should be excluded
 
         let plugins = list_installed_plugin_names(&bin_dir).unwrap();
@@ -2324,6 +2353,7 @@ sha256 = "bbb"
     #[test]
     fn helix_lsp_config_generates_languages_toml() {
         let project_dir = make_temp_dir("helix_lsp");
+        let expected_nu_path = format!(".nu-env/bin/{}", crate::installer::nu_env_binary_name());
 
         write_helix_lsp_config(&project_dir).unwrap();
 
@@ -2332,7 +2362,7 @@ sha256 = "bbb"
 
         let content = std::fs::read_to_string(&config_path).unwrap();
         assert!(content.contains("[language-server.nu-lsp]"));
-        assert!(content.contains("command = \".nu-env/bin/nu\""));
+        assert!(content.contains(&format!("command = \"{expected_nu_path}\"")));
         assert!(content.contains("\"--config\""));
         assert!(content.contains("\".nu-env/config.nu\""));
         assert!(content.contains("\"--plugin-config\""));
@@ -2345,6 +2375,7 @@ sha256 = "bbb"
     #[test]
     fn zed_lsp_config_generates_settings_json() {
         let project_dir = make_temp_dir("zed_lsp");
+        let expected_nu_path = format!(".nu-env/bin/{}", crate::installer::nu_env_binary_name());
 
         write_zed_lsp_config(&project_dir).unwrap();
 
@@ -2353,7 +2384,7 @@ sha256 = "bbb"
 
         let content = std::fs::read_to_string(&config_path).unwrap();
         assert!(content.contains("\"nu\""));
-        assert!(content.contains("\"path\": \".nu-env/bin/nu\""));
+        assert!(content.contains(&format!("\"path\": \"{expected_nu_path}\"")));
         assert!(content.contains("--config"));
         assert!(content.contains(".nu-env/config.nu"));
         assert!(content.contains("--plugin-config"));
@@ -2383,5 +2414,12 @@ sha256 = "bbb"
         assert!(err.to_string().contains("unknown editor"));
 
         let _ = std::fs::remove_dir_all(project_dir);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn pick_editors_requires_explicit_selection_on_windows() {
+        let err = pick_editors(&["helix", "zed"]).unwrap_err();
+        assert!(err.to_string().contains("not supported on Windows"));
     }
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::error::{QuiverError, Result};
 use crate::nu;
@@ -219,6 +219,14 @@ fn validate_ref_fields(
 }
 
 impl Manifest {
+    /// Find the nearest ancestor directory containing `nupackage.toml`.
+    pub fn find_project_dir(start: &Path) -> Option<PathBuf> {
+        start
+            .ancestors()
+            .find(|dir| dir.join("nupackage.toml").exists())
+            .map(Path::to_path_buf)
+    }
+
     /// Read and parse a `nupackage.toml` from the given directory.
     pub fn from_dir(dir: &Path) -> Result<Self> {
         let path = dir.join("nupackage.toml");
@@ -346,6 +354,17 @@ fn bare_key_or_quoted(key: &str) -> String {
 mod tests {
     use super::*;
     use std::collections::HashMap;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn make_temp_dir(prefix: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("quiver_manifest_{prefix}_{nanos}"));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
 
     #[test]
     fn round_trip_parse_manifest() {
@@ -607,5 +626,23 @@ nu_plugin_polars = { source = "nu-core", git = "https://example.com/x", tag = "v
 
         let err = Manifest::from_str(toml).unwrap_err();
         assert!(err.to_string().contains("source = 'nu-core'"));
+    }
+
+    #[test]
+    fn find_project_dir_walks_up_parent_directories() {
+        let root = make_temp_dir("find_project_dir");
+        let nested = root.join("src").join("commands");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(
+            root.join("nupackage.toml"),
+            "[package]\nname = \"demo\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+
+        let found = Manifest::find_project_dir(&nested);
+
+        assert_eq!(found.as_deref(), Some(root.as_path()));
+
+        let _ = std::fs::remove_dir_all(root);
     }
 }


### PR DESCRIPTION
## Added

- Project-local commands now discover the nearest enclosing `nupackage.toml` by walking up from the current working directory, so commands like `qv run amazing.nu` work from subdirectories of a Quiver project.

## Fixed

- Improved Windows compatibility for Quiver-managed Nushell binaries by consistently using the platform-specific `.nu-env/bin/nu` path (`nu.exe` on Windows) across `qvx`, generated project env files, plugin registration, and editor LSP configs.
- Global Quiver config and lockfile paths now use the platform config directory on windows and `~/.config` on macOS/linux.
- `qv lsp` now fails clearly on Windows when invoked without explicit editor names, instead of attempting to use the Unix-only interactive picker (hopefully switch to ratatui for this at some point).

