### PR TITLE
Quiver TUI! 

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,10 @@
 
 **quiver** is a module manager for [Nushell](https://www.nushell.sh/), written in Rust. It handles dependency resolution, fetching, and lockfile management for Nushell modules distributed as git repositories. Think of it as a minimal package manager (similar in spirit to `uv` or `cargo`) for the Nushell ecosystem.
 
+## Supported Platforms
+
+Quiver should run on macOS, Linux, and Windows.
+
 ## Architecture
 
 The codebase is a single-crate Rust CLI application. All source lives in `src/` with one file per responsibility:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Added
 
+- `qv` now launches a TUI where you can manage dependencies for your Quiver project. It includes a dependency graph, README and info viewer for installed dependencies, and an interactive mode to view dependency README's from github before adding them.
 - `qv lsp` now uses a Ratatui/Crossterm interactive picker, so editor selection works on Windows too.
 
 ## Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "ansi-to-tui"
+version = "8.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42366bb9d958f042bf58f0a85e1b2d091997c1257ca49bddd7e4827aadc65fd"
+dependencies = [
+ "nom 8.0.0",
+ "ratatui-core",
+ "simdutf8",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,6 +112,15 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bit-set"
@@ -400,6 +422,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -576,6 +604,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,6 +653,15 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -635,6 +714,12 @@ dependencies = [
  "openssl-sys",
  "url",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
@@ -967,6 +1052,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1102,6 +1193,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1147,6 +1247,28 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "onig"
+version = "6.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "openssl-probe"
@@ -1306,6 +1428,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1316,6 +1444,19 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "plist"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+dependencies = [
+ "base64",
+ "indexmap",
+ "quick-xml",
+ "serde",
+ "time",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -1339,6 +1480,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1349,12 +1500,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
+dependencies = [
+ "bitflags 2.11.0",
+ "getopts",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
+name = "quick-xml"
+version = "0.39.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "721da970c312655cde9b4ffe0547f20a8494866a4af5ff51f18b7c633d0c870b"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1377,6 +1565,7 @@ dependencies = [
  "tar",
  "thiserror 2.0.18",
  "toml",
+ "tui-markdown",
  "walkdir",
  "xz2",
  "zip",
@@ -1562,6 +1751,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.117",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1723,10 +1947,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -1807,6 +2043,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "syntect"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
+dependencies = [
+ "bincode",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "onig",
+ "plist",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror 2.0.18",
+ "walkdir",
+ "yaml-rust",
+]
+
+[[package]]
 name = "tar"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1824,7 +2081,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
 dependencies = [
  "fnv",
- "nom",
+ "nom 7.1.3",
  "phf",
  "phf_codegen",
 ]
@@ -1927,12 +2184,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "libc",
  "num-conv",
  "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -1940,6 +2199,16 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tinystr"
@@ -1976,6 +2245,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.25.4+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.0.9+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1989,6 +2270,53 @@ name = "toml_writer"
 version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "tui-markdown"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e766339aabad4528c3fccddf4acf03bc2b7ae6642def41e43c7af1a11f183122"
+dependencies = [
+ "ansi-to-tui",
+ "itertools",
+ "pretty_assertions",
+ "pulldown-cmark",
+ "ratatui-core",
+ "rstest",
+ "syntect",
+ "tracing",
+]
 
 [[package]]
 name = "typed-path"
@@ -2007,6 +2335,12 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -2352,6 +2686,9 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"
@@ -2465,6 +2802,21 @@ checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
 dependencies = [
  "lzma-sys",
 ]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ tar = "0.4"
 xz2 = "0.1"
 ratatui = "0.30"
 crossterm = "0.29"
+tui-markdown = "0.3"
 
 [dependencies.clap]
 version = "4"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -183,7 +183,7 @@ pub enum Commands {
 
     /// Generate editor-specific LSP configuration for Nushell
     Lsp {
-        /// Editors to configure (helix, zed). If omitted, shows an interactive picker.
+        /// Editors to configure (helix, vscode, zed). If omitted, shows an interactive picker.
         #[arg(long)]
         editor: Vec<String>,
     },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,7 +22,7 @@ pub struct Cli {
     pub version: Option<bool>,
 
     #[command(subcommand)]
-    pub command: Commands,
+    pub command: Option<Commands>,
 }
 
 #[derive(Parser, Debug)]
@@ -231,7 +231,7 @@ pub fn parse() -> Cli {
         let qvx = QvxCli::parse_from(args);
         return Cli {
             version: qvx.version,
-            command: Commands::Qvx {
+            command: Some(Commands::Qvx {
                 tag: qvx.tag,
                 rev: qvx.rev,
                 branch: qvx.branch,
@@ -239,7 +239,7 @@ pub fn parse() -> Cli {
                 source: qvx.source,
                 command: qvx.command,
                 args: qvx.args,
-            },
+            }),
         };
     }
     Cli::parse_from(args)
@@ -259,7 +259,7 @@ mod tests {
     #[test]
     fn remove_alias_parses() {
         let cli = Cli::try_parse_from(["quiver", "rm", "nu-utils"]).unwrap();
-        match cli.command {
+        match cli.command.unwrap() {
             Commands::Remove { global, name } => {
                 assert!(!global);
                 assert_eq!(name, "nu-utils");
@@ -271,19 +271,25 @@ mod tests {
     #[test]
     fn list_alias_parses() {
         let cli = Cli::try_parse_from(["quiver", "ls"]).unwrap();
-        assert!(matches!(cli.command, Commands::List));
+        assert!(matches!(cli.command, Some(Commands::List)));
     }
 
     #[test]
     fn version_subcommand_parses() {
         let cli = Cli::try_parse_from(["quiver", "version"]).unwrap();
-        assert!(matches!(cli.command, Commands::Version));
+        assert!(matches!(cli.command, Some(Commands::Version)));
+    }
+
+    #[test]
+    fn no_subcommand_parses_for_tui() {
+        let cli = Cli::try_parse_from(["quiver"]).unwrap();
+        assert!(cli.command.is_none());
     }
 
     #[test]
     fn run_subcommand_parses_with_multiple_args() {
         let cli = Cli::try_parse_from(["quiver", "run", "nu", "script.nu", "--flag"]).unwrap();
-        match cli.command {
+        match cli.command.unwrap() {
             Commands::Run { command } => {
                 assert_eq!(command, vec!["nu", "script.nu", "--flag"]);
             }
@@ -302,7 +308,7 @@ mod tests {
             ".",
         ])
         .unwrap();
-        match cli.command {
+        match cli.command.unwrap() {
             Commands::Qvx {
                 tag,
                 rev,
@@ -337,7 +343,7 @@ mod tests {
             "plain",
         ])
         .unwrap();
-        match cli.command {
+        match cli.command.unwrap() {
             Commands::Qvx {
                 branch,
                 source,
@@ -365,7 +371,7 @@ mod tests {
             "generate-doc-site",
         ])
         .unwrap();
-        match cli.command {
+        match cli.command.unwrap() {
             Commands::Qvx {
                 nu_version,
                 source,
@@ -405,7 +411,7 @@ mod tests {
             "nu_plugin_inc",
         ])
         .unwrap();
-        match cli.command {
+        match cli.command.unwrap() {
             Commands::AddPlugin {
                 global,
                 url,
@@ -428,7 +434,7 @@ mod tests {
     #[test]
     fn init_parses_with_nu_version() {
         let cli = Cli::try_parse_from(["quiver", "init", "--nu-version", "0.109.0"]).unwrap();
-        match cli.command {
+        match cli.command.unwrap() {
             Commands::Init {
                 name,
                 version,
@@ -453,7 +459,7 @@ mod tests {
             "--no-build-fallback",
         ])
         .unwrap();
-        match cli.command {
+        match cli.command.unwrap() {
             Commands::Install {
                 global,
                 frozen,

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -33,7 +33,7 @@ pub struct LockedPackage {
 /// The kind of installed artifact in the lockfile.
 ///
 /// Unknown kinds are preserved for forward compatibility.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum LockedPackageKind {
     #[default]

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod manifest;
 mod nu;
 mod resolver;
 mod safety;
+mod tui;
 mod ui;
 
 use std::collections::HashMap;
@@ -38,22 +39,23 @@ fn main() {
     }
 }
 
-fn run(command: Commands) -> Result<()> {
+fn run(command: Option<Commands>) -> Result<()> {
     let cwd = std::env::current_dir()?;
 
     match command {
-        Commands::Init {
+        None => cmd_tui(&cwd),
+        Some(Commands::Init {
             name,
             version,
             nu_version,
             description,
-        } => cmd_init(&cwd, name, version, nu_version, description),
-        Commands::Install {
+        }) => cmd_init(&cwd, name, version, nu_version, description),
+        Some(Commands::Install {
             global,
             frozen,
             allow_unsigned,
             no_build_fallback,
-        } => {
+        }) => {
             if global {
                 cmd_install_global(frozen, allow_unsigned, no_build_fallback)
             } else {
@@ -61,17 +63,17 @@ fn run(command: Commands) -> Result<()> {
                 cmd_install(&project_dir, frozen, allow_unsigned, no_build_fallback)
             }
         }
-        Commands::Update => {
+        Some(Commands::Update) => {
             let project_dir = require_project_dir(&cwd)?;
             cmd_update(&project_dir)
         }
-        Commands::Add {
+        Some(Commands::Add {
             global,
             url,
             tag,
             rev,
             branch,
-        } => {
+        }) => {
             if global {
                 cmd_add_global(url, tag, rev, branch)
             } else {
@@ -79,14 +81,14 @@ fn run(command: Commands) -> Result<()> {
                 cmd_add(&project_dir, url, tag, rev, branch)
             }
         }
-        Commands::AddPlugin {
+        Some(Commands::AddPlugin {
             global,
             url,
             tag,
             rev,
             branch,
             bin,
-        } => {
+        }) => {
             if global {
                 cmd_add_global_plugin(url, tag, rev, branch, bin)
             } else {
@@ -94,7 +96,7 @@ fn run(command: Commands) -> Result<()> {
                 cmd_add_plugin(&project_dir, url, tag, rev, branch, bin)
             }
         }
-        Commands::Remove { global, name } => {
+        Some(Commands::Remove { global, name }) => {
             if global {
                 cmd_remove_global(name)
             } else {
@@ -102,15 +104,15 @@ fn run(command: Commands) -> Result<()> {
                 cmd_remove(&project_dir, name)
             }
         }
-        Commands::List => cmd_list(&cwd),
-        Commands::Version => cmd_version(),
-        Commands::Hook => cmd_hook(),
-        Commands::Lsp { editor } => {
+        Some(Commands::List) => cmd_list(&cwd),
+        Some(Commands::Version) => cmd_version(),
+        Some(Commands::Hook) => cmd_hook(),
+        Some(Commands::Lsp { editor }) => {
             let project_dir = require_project_dir(&cwd)?;
             cmd_lsp(&project_dir, editor)
         }
-        Commands::Run { command } => cmd_run(&cwd, command),
-        Commands::Qvx {
+        Some(Commands::Run { command }) => cmd_run(&cwd, command),
+        Some(Commands::Qvx {
             tag,
             rev,
             branch,
@@ -118,7 +120,36 @@ fn run(command: Commands) -> Result<()> {
             source,
             command,
             args,
-        } => cmd_qvx(&cwd, source, tag, rev, branch, nu_version, command, args),
+        }) => cmd_qvx(&cwd, source, tag, rev, branch, nu_version, command, args),
+    }
+}
+
+fn cmd_tui(cwd: &Path) -> Result<()> {
+    let Some(action) = tui::run(cwd)? else {
+        return Ok(());
+    };
+
+    match action {
+        tui::TuiAction::Install => {
+            let project_dir = require_project_dir(cwd)?;
+            cmd_install(&project_dir, false, false, false)
+        }
+        tui::TuiAction::Update => {
+            let project_dir = require_project_dir(cwd)?;
+            cmd_update(&project_dir)
+        }
+        tui::TuiAction::Remove { name } => {
+            let project_dir = require_project_dir(cwd)?;
+            cmd_remove(&project_dir, name)
+        }
+        tui::TuiAction::AddModule { url } => {
+            let project_dir = require_project_dir(cwd)?;
+            cmd_add(&project_dir, url, None, None, None)
+        }
+        tui::TuiAction::AddPlugin { url } => {
+            let project_dir = require_project_dir(cwd)?;
+            cmd_add_plugin(&project_dir, url, None, None, None, None)
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1106,7 +1106,7 @@ fn cmd_version() -> Result<()> {
 }
 
 fn cmd_lsp(cwd: &Path, editors: Vec<String>) -> Result<()> {
-    let all_editors = ["helix", "zed"];
+    let all_editors = ["helix", "vscode", "zed"];
 
     let selected: Vec<String> = if editors.is_empty() {
         // Interactive picker
@@ -1134,6 +1134,7 @@ fn cmd_lsp(cwd: &Path, editors: Vec<String>) -> Result<()> {
     for editor in &selected {
         match editor.as_str() {
             "helix" => write_helix_lsp_config(cwd)?,
+            "vscode" => write_vscode_lsp_config(cwd)?,
             "zed" => write_zed_lsp_config(cwd)?,
             _ => {}
         }
@@ -1295,6 +1296,46 @@ args = [
 
     std::fs::write(&config_path, config)?;
     eprintln!("Generated .helix/languages.toml");
+    Ok(())
+}
+
+fn write_vscode_lsp_config(project_dir: &Path) -> Result<()> {
+    let vscode_dir = project_dir.join(".vscode");
+    std::fs::create_dir_all(&vscode_dir)?;
+
+    let config_path = vscode_dir.join("settings.json");
+    let nu_bin_path = project_dir
+        .join(".nu-env")
+        .join("bin")
+        .join(installer::nu_env_binary_name());
+
+    let nu_bin_path_str = nu_bin_path.to_string_lossy().into_owned();
+
+    let mut settings = serde_json::json!({});
+    if config_path.exists() {
+        if let Ok(content) = std::fs::read_to_string(&config_path) {
+            if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&content) {
+                if parsed.is_object() {
+                    settings = parsed;
+                }
+            }
+        }
+    }
+
+    if let Some(obj) = settings.as_object_mut() {
+        obj.insert(
+            "nushellLanguageServer.includeDirs".to_string(),
+            serde_json::json!([".nu-env/modules/"]),
+        );
+        obj.insert(
+            "nushellLanguageServer.nushellExecutablePath".to_string(),
+            serde_json::json!(nu_bin_path_str),
+        );
+    }
+
+    let config = serde_json::to_string_pretty(&settings).unwrap_or_default() + "\n";
+    std::fs::write(&config_path, config)?;
+    eprintln!("Generated .vscode/settings.json");
     Ok(())
 }
 
@@ -2430,9 +2471,18 @@ sha256 = "bbb"
     fn cmd_lsp_with_explicit_editors_generates_configs() {
         let project_dir = make_temp_dir("lsp_explicit");
 
-        cmd_lsp(&project_dir, vec!["helix".to_string(), "zed".to_string()]).unwrap();
+        cmd_lsp(
+            &project_dir,
+            vec![
+                "helix".to_string(),
+                "vscode".to_string(),
+                "zed".to_string(),
+            ],
+        )
+        .unwrap();
 
         assert!(project_dir.join(".helix").join("languages.toml").exists());
+        assert!(project_dir.join(".vscode").join("settings.json").exists());
         assert!(project_dir.join(".zed").join("settings.json").exists());
 
         let _ = std::fs::remove_dir_all(project_dir);

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,0 +1,762 @@
+use std::collections::{HashMap, HashSet};
+use std::io::{self, IsTerminal};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crossterm::{
+    event::{self, Event, KeyCode, KeyEventKind, KeyModifiers},
+    execute,
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+};
+use ratatui::{
+    Terminal,
+    backend::CrosstermBackend,
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{
+        Block, Borders, Clear, List, ListItem, ListState, Paragraph, Scrollbar,
+        ScrollbarOrientation, ScrollbarState, Tabs, Wrap,
+    },
+};
+
+use crate::error::{QuiverError, Result};
+use crate::lockfile::{LockedPackageKind, Lockfile};
+use crate::manifest::Manifest;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TuiAction {
+    Install,
+    Update,
+    Remove { name: String },
+    AddModule { url: String },
+    AddPlugin { url: String },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Tab {
+    Dependencies,
+    Graph,
+    Search,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum InputMode {
+    Normal,
+    AddUrl,
+    ConfirmRemove { name: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum DependencyKind {
+    Module,
+    Plugin,
+    Transitive,
+}
+
+#[derive(Debug, Clone)]
+struct DependencyRow {
+    name: String,
+    kind: DependencyKind,
+    git: String,
+    requested: String,
+    locked_rev: Option<String>,
+    checksum: Option<String>,
+}
+
+struct App {
+    project_dir: Option<PathBuf>,
+    package_name: String,
+    package_version: String,
+    rows: Vec<DependencyRow>,
+    tab: Tab,
+    selected: usize,
+    readme_scroll: u16,
+    status: String,
+    input: String,
+    readme_url: String,
+    readme: String,
+    input_mode: InputMode,
+    action: Option<TuiAction>,
+    quit: bool,
+}
+
+pub fn run(cwd: &Path) -> Result<Option<TuiAction>> {
+    if !io::stderr().is_terminal() {
+        return Err(QuiverError::Other(
+            "qv without a subcommand opens the TUI; run it in an interactive terminal".to_string(),
+        ));
+    }
+
+    let mut app = App::load(cwd)?;
+
+    enable_raw_mode()?;
+    let mut stderr = io::stderr();
+    execute!(stderr, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stderr);
+    let mut terminal = Terminal::new(backend)?;
+
+    let tui_result = (|| -> Result<Option<TuiAction>> {
+        loop {
+            terminal.draw(|frame| render(frame, &mut app))?;
+
+            if let Event::Key(key) = event::read()? {
+                if key.kind != KeyEventKind::Press {
+                    continue;
+                }
+                handle_key(&mut app, key.code, key.modifiers);
+                if app.quit || app.action.is_some() {
+                    break;
+                }
+            }
+        }
+
+        Ok(app.action.take())
+    })();
+
+    let cleanup_result = (|| -> io::Result<()> {
+        disable_raw_mode()?;
+        execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+        terminal.show_cursor()?;
+        Ok(())
+    })();
+
+    match (tui_result, cleanup_result) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Err(err), Ok(())) => Err(err),
+        (Ok(_), Err(err)) | (Err(_), Err(err)) => Err(err.into()),
+    }
+}
+
+impl App {
+    fn load(cwd: &Path) -> Result<Self> {
+        let Some(project_dir) = Manifest::find_project_dir(cwd) else {
+            return Ok(Self {
+                project_dir: None,
+                package_name: "No quiver project".to_string(),
+                package_version: String::new(),
+                rows: Vec::new(),
+                tab: Tab::Dependencies,
+                selected: 0,
+                readme_scroll: 0,
+                status: "Run qv init to create nupackage.toml, or q to quit.".to_string(),
+                input: String::new(),
+                readme_url: String::new(),
+                readme: "No nupackage.toml was found in this directory or its parents.".to_string(),
+                input_mode: InputMode::Normal,
+                action: None,
+                quit: false,
+            });
+        };
+
+        let manifest = Manifest::from_dir(&project_dir)?;
+        let lockfile = read_lockfile(&project_dir)?;
+        let rows = dependency_rows(&manifest, lockfile.as_ref());
+        let status = if rows.is_empty() {
+            "No dependencies yet. Press a to paste a GitHub URL.".to_string()
+        } else {
+            "Use up/down to inspect dependencies; g opens the graph; a adds from GitHub."
+                .to_string()
+        };
+
+        Ok(Self {
+            project_dir: Some(project_dir),
+            package_name: manifest.package.name,
+            package_version: manifest.package.version,
+            rows,
+            tab: Tab::Dependencies,
+            selected: 0,
+            readme_scroll: 0,
+            status,
+            input: String::new(),
+            readme_url: String::new(),
+            readme: "Paste a GitHub repository URL, then press Enter to preview its README."
+                .to_string(),
+            input_mode: InputMode::Normal,
+            action: None,
+            quit: false,
+        })
+    }
+
+    fn selected_row(&self) -> Option<&DependencyRow> {
+        self.rows.get(self.selected)
+    }
+
+    fn can_manage(&self) -> bool {
+        self.project_dir.is_some()
+    }
+}
+
+fn read_lockfile(project_dir: &Path) -> Result<Option<Lockfile>> {
+    let path = project_dir.join("quiver.lock");
+    if path.exists() {
+        Ok(Some(Lockfile::from_path(&path)?))
+    } else {
+        Ok(None)
+    }
+}
+
+fn dependency_rows(manifest: &Manifest, lockfile: Option<&Lockfile>) -> Vec<DependencyRow> {
+    let mut locked_by_name = HashMap::new();
+    if let Some(lockfile) = lockfile {
+        for package in &lockfile.packages {
+            locked_by_name.insert((package.name.clone(), package.kind.clone()), package);
+        }
+    }
+
+    let mut rows = Vec::new();
+    let mut direct_names = HashSet::new();
+
+    let mut modules: Vec<_> = manifest.dependencies.modules.iter().collect();
+    modules.sort_by(|a, b| a.0.cmp(b.0));
+    for (name, spec) in modules {
+        direct_names.insert((name.clone(), LockedPackageKind::Module));
+        let locked = locked_by_name.get(&(name.clone(), LockedPackageKind::Module));
+        rows.push(DependencyRow {
+            name: name.clone(),
+            kind: DependencyKind::Module,
+            git: spec.git.clone(),
+            requested: requested_ref(&spec.tag, &spec.rev, &spec.branch),
+            locked_rev: locked.map(|p| p.rev.clone()),
+            checksum: locked.map(|p| p.sha256.clone()),
+        });
+    }
+
+    let mut plugins: Vec<_> = manifest.dependencies.plugins.iter().collect();
+    plugins.sort_by(|a, b| a.0.cmp(b.0));
+    for (name, spec) in plugins {
+        direct_names.insert((name.clone(), LockedPackageKind::Plugin));
+        let locked = locked_by_name.get(&(name.clone(), LockedPackageKind::Plugin));
+        rows.push(DependencyRow {
+            name: name.clone(),
+            kind: DependencyKind::Plugin,
+            git: if spec.git.is_empty() {
+                spec.source.as_deref().unwrap_or("nu-core").to_string()
+            } else {
+                spec.git.clone()
+            },
+            requested: requested_ref(&spec.tag, &spec.rev, &spec.branch),
+            locked_rev: locked.map(|p| p.rev.clone()),
+            checksum: locked.map(|p| p.sha256.clone()),
+        });
+    }
+
+    if let Some(lockfile) = lockfile {
+        let mut transitive: Vec<_> = lockfile
+            .packages
+            .iter()
+            .filter(|package| {
+                package.kind == LockedPackageKind::Module
+                    && !direct_names.contains(&(package.name.clone(), package.kind.clone()))
+            })
+            .collect();
+        transitive.sort_by(|a, b| a.name.cmp(&b.name));
+        for package in transitive {
+            rows.push(DependencyRow {
+                name: package.name.clone(),
+                kind: DependencyKind::Transitive,
+                git: package.git.clone(),
+                requested: package.tag.clone().unwrap_or_else(|| "locked".to_string()),
+                locked_rev: Some(package.rev.clone()),
+                checksum: Some(package.sha256.clone()),
+            });
+        }
+    }
+
+    rows
+}
+
+fn requested_ref(tag: &Option<String>, rev: &Option<String>, branch: &Option<String>) -> String {
+    if let Some(tag) = tag {
+        format!("tag {tag}")
+    } else if let Some(rev) = rev {
+        format!("rev {}", short_rev(rev))
+    } else if let Some(branch) = branch {
+        format!("branch {branch}")
+    } else {
+        "none".to_string()
+    }
+}
+
+fn render(frame: &mut ratatui::Frame<'_>, app: &mut App) {
+    let area = frame.area();
+    let shell = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(8),
+            Constraint::Length(3),
+        ])
+        .split(area);
+
+    render_header(frame, app, shell[0]);
+    match app.tab {
+        Tab::Dependencies => render_dependencies(frame, app, shell[1]),
+        Tab::Graph => render_graph(frame, app, shell[1]),
+        Tab::Search => render_search(frame, app, shell[1]),
+    }
+    render_footer(frame, app, shell[2]);
+
+    match &app.input_mode {
+        InputMode::AddUrl => render_input(frame, app, "Paste GitHub repository URL"),
+        InputMode::ConfirmRemove { name } => {
+            render_confirm(frame, &format!("Remove '{name}' from nupackage.toml? y/N"))
+        }
+        InputMode::Normal => {}
+    }
+}
+
+fn render_header(frame: &mut ratatui::Frame<'_>, app: &App, area: Rect) {
+    let titles = ["Dependencies", "Graph", "GitHub README"]
+        .iter()
+        .map(|title| Line::from(Span::styled(*title, Style::default().fg(Color::Cyan))))
+        .collect::<Vec<_>>();
+    let selected = match app.tab {
+        Tab::Dependencies => 0,
+        Tab::Graph => 1,
+        Tab::Search => 2,
+    };
+    let title = if app.package_version.is_empty() {
+        app.package_name.clone()
+    } else {
+        format!("{} {}", app.package_name, app.package_version)
+    };
+    let tabs = Tabs::new(titles)
+        .select(selected)
+        .block(Block::default().title(title).borders(Borders::ALL))
+        .highlight_style(
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        );
+    frame.render_widget(tabs, area);
+}
+
+fn render_dependencies(frame: &mut ratatui::Frame<'_>, app: &mut App, area: Rect) {
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(42), Constraint::Percentage(58)])
+        .split(area);
+
+    let items = if app.rows.is_empty() {
+        vec![ListItem::new("No dependencies")]
+    } else {
+        app.rows
+            .iter()
+            .map(|row| {
+                let status = if row.locked_rev.is_some() {
+                    "locked"
+                } else {
+                    "missing"
+                };
+                ListItem::new(Line::from(vec![
+                    Span::styled(kind_label(&row.kind), kind_style(&row.kind)),
+                    Span::raw(" "),
+                    Span::styled(&row.name, Style::default().add_modifier(Modifier::BOLD)),
+                    Span::raw(format!("  {status}")),
+                ]))
+            })
+            .collect()
+    };
+    let list = List::new(items)
+        .block(Block::default().title("Dependencies").borders(Borders::ALL))
+        .highlight_symbol("> ")
+        .highlight_style(
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        );
+    let mut list_state = ListState::default();
+    if !app.rows.is_empty() {
+        list_state.select(Some(app.selected));
+    }
+    frame.render_stateful_widget(list, chunks[0], &mut list_state);
+
+    let detail = selected_detail(app);
+    frame.render_widget(
+        Paragraph::new(detail)
+            .block(Block::default().title("Details").borders(Borders::ALL))
+            .wrap(Wrap { trim: false }),
+        chunks[1],
+    );
+}
+
+fn selected_detail(app: &App) -> String {
+    let Some(row) = app.selected_row() else {
+        return "Press a to paste a GitHub repository URL and preview its README.".to_string();
+    };
+
+    let mut detail = String::new();
+    detail.push_str(&format!("name: {}\n", row.name));
+    detail.push_str(&format!("kind: {}\n", kind_label(&row.kind)));
+    detail.push_str(&format!("source: {}\n", row.git));
+    detail.push_str(&format!("requested: {}\n", row.requested));
+    if let Some(rev) = &row.locked_rev {
+        detail.push_str(&format!("locked rev: {}\n", rev));
+    } else {
+        detail.push_str("locked rev: not installed\n");
+    }
+    if let Some(checksum) = &row.checksum {
+        detail.push_str(&format!("sha256: {}\n", checksum));
+    }
+    detail
+}
+
+fn render_graph(frame: &mut ratatui::Frame<'_>, app: &App, area: Rect) {
+    let mut lines = Vec::new();
+    lines.push(app.package_name.clone());
+
+    let direct_count = app
+        .rows
+        .iter()
+        .filter(|row| !matches!(row.kind, DependencyKind::Transitive))
+        .count();
+    for (index, row) in app
+        .rows
+        .iter()
+        .filter(|row| !matches!(row.kind, DependencyKind::Transitive))
+        .enumerate()
+    {
+        let prefix = if index + 1 == direct_count {
+            "`--"
+        } else {
+            "|--"
+        };
+        lines.push(format!("{prefix} {} ({})", row.name, kind_label(&row.kind)));
+    }
+
+    let transitive: Vec<_> = app
+        .rows
+        .iter()
+        .filter(|row| matches!(row.kind, DependencyKind::Transitive))
+        .collect();
+    if !transitive.is_empty() {
+        lines.push("`-- transitive modules from quiver.lock".to_string());
+        for row in transitive {
+            lines.push(format!("    |-- {} ({})", row.name, row.requested));
+        }
+    }
+
+    if lines.len() == 1 {
+        lines.push("`-- no dependencies".to_string());
+    }
+
+    frame.render_widget(
+        Paragraph::new(lines.join("\n"))
+            .block(
+                Block::default()
+                    .title("Dependency Graph")
+                    .borders(Borders::ALL),
+            )
+            .wrap(Wrap { trim: false }),
+        area,
+    );
+}
+
+fn render_search(frame: &mut ratatui::Frame<'_>, app: &mut App, area: Rect) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(3), Constraint::Min(5)])
+        .split(area);
+
+    let url = if app.readme_url.is_empty() {
+        "No repository loaded".to_string()
+    } else {
+        app.readme_url.clone()
+    };
+    frame.render_widget(
+        Paragraph::new(url).block(Block::default().title("Repository").borders(Borders::ALL)),
+        chunks[0],
+    );
+
+    let paragraph = Paragraph::new(app.readme.as_str())
+        .block(Block::default().title("README").borders(Borders::ALL))
+        .scroll((app.readme_scroll, 0))
+        .wrap(Wrap { trim: false });
+    frame.render_widget(paragraph, chunks[1]);
+
+    let content_height = app.readme.lines().count().saturating_sub(1) as u16;
+    let mut scrollbar_state =
+        ScrollbarState::new(content_height as usize).position(app.readme_scroll as usize);
+    frame.render_stateful_widget(
+        Scrollbar::new(ScrollbarOrientation::VerticalRight),
+        chunks[1],
+        &mut scrollbar_state,
+    );
+}
+
+fn render_footer(frame: &mut ratatui::Frame<'_>, app: &App, area: Rect) {
+    let keys = match app.tab {
+        Tab::Dependencies => {
+            "q quit | tab switch | i install | u update | r remove | a add URL | g graph"
+        }
+        Tab::Graph => "q quit | tab switch | d dependencies | a add URL",
+        Tab::Search => {
+            "q quit | tab switch | a paste URL | m add module | p add plugin | j/k scroll"
+        }
+    };
+    let text = format!("{keys}\n{}", app.status);
+    frame.render_widget(
+        Paragraph::new(text)
+            .block(Block::default().borders(Borders::ALL))
+            .wrap(Wrap { trim: true }),
+        area,
+    );
+}
+
+fn render_input(frame: &mut ratatui::Frame<'_>, app: &App, title: &str) {
+    let area = centered_rect(70, 20, frame.area());
+    frame.render_widget(Clear, area);
+    frame.render_widget(
+        Paragraph::new(app.input.as_str())
+            .block(Block::default().title(title).borders(Borders::ALL)),
+        area,
+    );
+}
+
+fn render_confirm(frame: &mut ratatui::Frame<'_>, message: &str) {
+    let area = centered_rect(60, 20, frame.area());
+    frame.render_widget(Clear, area);
+    frame.render_widget(
+        Paragraph::new(message)
+            .alignment(Alignment::Center)
+            .block(Block::default().title("Confirm").borders(Borders::ALL)),
+        area,
+    );
+}
+
+fn handle_key(app: &mut App, code: KeyCode, modifiers: KeyModifiers) {
+    match app.input_mode.clone() {
+        InputMode::Normal => handle_normal_key(app, code, modifiers),
+        InputMode::AddUrl => handle_url_key(app, code),
+        InputMode::ConfirmRemove { name } => handle_remove_confirm_key(app, code, name),
+    }
+}
+
+fn handle_normal_key(app: &mut App, code: KeyCode, modifiers: KeyModifiers) {
+    match code {
+        KeyCode::Char('c') if modifiers.contains(KeyModifiers::CONTROL) => app.quit = true,
+        KeyCode::Char('q') | KeyCode::Esc => app.quit = true,
+        KeyCode::Tab | KeyCode::Right => app.tab = next_tab(app.tab),
+        KeyCode::BackTab | KeyCode::Left => app.tab = previous_tab(app.tab),
+        KeyCode::Char('d') => app.tab = Tab::Dependencies,
+        KeyCode::Char('g') => app.tab = Tab::Graph,
+        KeyCode::Char('s') => app.tab = Tab::Search,
+        KeyCode::Down | KeyCode::Char('j') => {
+            if app.tab == Tab::Search {
+                app.readme_scroll = app.readme_scroll.saturating_add(1);
+            } else if app.selected + 1 < app.rows.len() {
+                app.selected += 1;
+            }
+        }
+        KeyCode::Up | KeyCode::Char('k') => {
+            if app.tab == Tab::Search {
+                app.readme_scroll = app.readme_scroll.saturating_sub(1);
+            } else {
+                app.selected = app.selected.saturating_sub(1);
+            }
+        }
+        KeyCode::Home => {
+            if app.tab == Tab::Search {
+                app.readme_scroll = 0;
+            } else {
+                app.selected = 0;
+            }
+        }
+        KeyCode::Char('i') if app.can_manage() => app.action = Some(TuiAction::Install),
+        KeyCode::Char('u') if app.can_manage() => app.action = Some(TuiAction::Update),
+        KeyCode::Char('a') if app.can_manage() => {
+            app.tab = Tab::Search;
+            app.input.clear();
+            app.input_mode = InputMode::AddUrl;
+        }
+        KeyCode::Char('r') if app.can_manage() => {
+            if let Some(row) = app.selected_row()
+                && !matches!(row.kind, DependencyKind::Transitive)
+            {
+                app.input_mode = InputMode::ConfirmRemove {
+                    name: row.name.clone(),
+                };
+            }
+        }
+        KeyCode::Char('m') if app.can_manage() && !app.readme_url.is_empty() => {
+            app.action = Some(TuiAction::AddModule {
+                url: app.readme_url.clone(),
+            });
+        }
+        KeyCode::Char('p') if app.can_manage() && !app.readme_url.is_empty() => {
+            app.action = Some(TuiAction::AddPlugin {
+                url: app.readme_url.clone(),
+            });
+        }
+        _ => {}
+    }
+}
+
+fn handle_url_key(app: &mut App, code: KeyCode) {
+    match code {
+        KeyCode::Enter => {
+            let url = app.input.trim().to_string();
+            if url.is_empty() {
+                app.status = "Paste a GitHub repository URL first.".to_string();
+            } else {
+                app.readme_url = url.clone();
+                app.status = format!("Fetching README for {url}");
+                match fetch_github_readme(&url) {
+                    Ok(readme) => {
+                        app.readme = readme;
+                        app.readme_scroll = 0;
+                        app.status =
+                            "README loaded. Press m to add as module, or p to add as plugin."
+                                .to_string();
+                    }
+                    Err(err) => {
+                        app.readme = format!("{err}");
+                        app.status = "Could not load README.".to_string();
+                    }
+                }
+            }
+            app.input_mode = InputMode::Normal;
+        }
+        KeyCode::Esc => app.input_mode = InputMode::Normal,
+        KeyCode::Backspace => {
+            app.input.pop();
+        }
+        KeyCode::Char(c) => app.input.push(c),
+        _ => {}
+    }
+}
+
+fn handle_remove_confirm_key(app: &mut App, code: KeyCode, name: String) {
+    match code {
+        KeyCode::Char('y') | KeyCode::Char('Y') => app.action = Some(TuiAction::Remove { name }),
+        _ => app.input_mode = InputMode::Normal,
+    }
+}
+
+fn fetch_github_readme(url: &str) -> Result<String> {
+    let (owner, repo) = parse_github_owner_repo(url).ok_or_else(|| {
+        QuiverError::Other("expected a GitHub URL like https://github.com/owner/repo".to_string())
+    })?;
+    let api_url = format!("https://api.github.com/repos/{owner}/{repo}/readme");
+    let output = Command::new("curl")
+        .arg("-fsSL")
+        .arg("-H")
+        .arg("Accept: application/vnd.github.raw")
+        .arg("-H")
+        .arg("User-Agent: quiver")
+        .arg(api_url)
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(QuiverError::Other(format!(
+            "failed to fetch README for {owner}/{repo}: {}",
+            stderr.trim()
+        )));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+fn parse_github_owner_repo(url: &str) -> Option<(String, String)> {
+    let trimmed = url
+        .trim()
+        .split(['?', '#'])
+        .next()
+        .unwrap_or_default()
+        .trim_end_matches('/')
+        .trim_end_matches(".git");
+    let rest = trimmed
+        .strip_prefix("https://github.com/")
+        .or_else(|| trimmed.strip_prefix("git@github.com:"))?;
+    let mut parts = rest.split('/');
+    let owner = parts.next()?.trim();
+    let repo = parts.next()?.trim();
+    if owner.is_empty() || repo.is_empty() {
+        return None;
+    }
+    Some((owner.to_string(), repo.to_string()))
+}
+
+fn kind_label(kind: &DependencyKind) -> &'static str {
+    match kind {
+        DependencyKind::Module => "module",
+        DependencyKind::Plugin => "plugin",
+        DependencyKind::Transitive => "transitive",
+    }
+}
+
+fn kind_style(kind: &DependencyKind) -> Style {
+    match kind {
+        DependencyKind::Module => Style::default().fg(Color::Cyan),
+        DependencyKind::Plugin => Style::default().fg(Color::Magenta),
+        DependencyKind::Transitive => Style::default().fg(Color::Gray),
+    }
+}
+
+fn short_rev(rev: &str) -> &str {
+    rev.get(..12).unwrap_or(rev)
+}
+
+fn next_tab(tab: Tab) -> Tab {
+    match tab {
+        Tab::Dependencies => Tab::Graph,
+        Tab::Graph => Tab::Search,
+        Tab::Search => Tab::Dependencies,
+    }
+}
+
+fn previous_tab(tab: Tab) -> Tab {
+    match tab {
+        Tab::Dependencies => Tab::Search,
+        Tab::Graph => Tab::Dependencies,
+        Tab::Search => Tab::Graph,
+    }
+}
+
+fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
+    let vertical = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(area);
+
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(vertical[1])[1]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_github_url() {
+        assert_eq!(
+            parse_github_owner_repo("https://github.com/freepicheep/quiver.git/"),
+            Some(("freepicheep".to_string(), "quiver".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_github_url_with_extra_path() {
+        assert_eq!(
+            parse_github_owner_repo("https://github.com/freepicheep/quiver/tree/main"),
+            Some(("freepicheep".to_string(), "quiver".to_string()))
+        );
+    }
+
+    #[test]
+    fn rejects_non_github_url() {
+        assert_eq!(parse_github_owner_repo("https://example.com/a/b"), None);
+    }
+}

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -4,7 +4,10 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crossterm::{
-    event::{self, Event, KeyCode, KeyEventKind, KeyModifiers, EnableMouseCapture, DisableMouseCapture, MouseEventKind},
+    event::{
+        self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind, KeyModifiers,
+        MouseEventKind,
+    },
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
@@ -23,6 +26,17 @@ use ratatui::{
 use crate::error::{QuiverError, Result};
 use crate::lockfile::{LockedPackageKind, Lockfile};
 use crate::manifest::Manifest;
+
+const BUILTIN_PLUGINS: &[&str] = &[
+    "nu_plugin_custom_values",
+    "nu_plugin_example",
+    "nu_plugin_formats",
+    "nu_plugin_gstat",
+    "nu_plugin_inc",
+    "nu_plugin_polars",
+    "nu_plugin_query",
+    "nu_plugin_stress_internals",
+];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TuiAction {
@@ -72,8 +86,10 @@ struct App {
     rows: Vec<DependencyRow>,
     tab: Tab,
     selected: usize,
+    search_selected: usize,
     readme_scroll: u16,
     detail_readme_scroll: u16,
+    graph_scroll: u16,
     local_readme: String,
     local_license: String,
     status: String,
@@ -124,6 +140,12 @@ pub fn run(cwd: &Path) -> Result<Option<TuiAction>> {
                     MouseEventKind::ScrollUp if app.tab == Tab::Search => {
                         app.readme_scroll = app.readme_scroll.saturating_sub(3);
                     }
+                    MouseEventKind::ScrollDown if app.tab == Tab::Graph => {
+                        app.graph_scroll = app.graph_scroll.saturating_add(3);
+                    }
+                    MouseEventKind::ScrollUp if app.tab == Tab::Graph => {
+                        app.graph_scroll = app.graph_scroll.saturating_sub(3);
+                    }
                     _ => {}
                 },
                 _ => continue,
@@ -138,7 +160,11 @@ pub fn run(cwd: &Path) -> Result<Option<TuiAction>> {
 
     let cleanup_result = (|| -> io::Result<()> {
         disable_raw_mode()?;
-        execute!(terminal.backend_mut(), LeaveAlternateScreen, DisableMouseCapture)?;
+        execute!(
+            terminal.backend_mut(),
+            LeaveAlternateScreen,
+            DisableMouseCapture
+        )?;
         terminal.show_cursor()?;
         Ok(())
     })();
@@ -160,8 +186,10 @@ impl App {
                 rows: Vec::new(),
                 tab: Tab::Dependencies,
                 selected: 0,
+                search_selected: 0,
                 readme_scroll: 0,
                 detail_readme_scroll: 0,
+                graph_scroll: 0,
                 local_readme: String::new(),
                 local_license: String::new(),
                 status: "Run qv init to create nupackage.toml, or q to quit.".to_string(),
@@ -196,8 +224,10 @@ impl App {
             rows,
             tab: Tab::Dependencies,
             selected: 0,
+            search_selected: 0,
             readme_scroll: 0,
             detail_readme_scroll: 0,
+            graph_scroll: 0,
             local_readme,
             local_license,
             status,
@@ -343,7 +373,7 @@ fn render(frame: &mut ratatui::Frame<'_>, app: &mut App) {
 }
 
 fn render_header(frame: &mut ratatui::Frame<'_>, app: &App, area: Rect) {
-    let titles = ["Dependencies", "Graph", "GitHub README"]
+    let titles = ["Dependencies", "Graph", "Add"]
         .iter()
         .map(|title| Line::from(Span::styled(*title, Style::default().fg(Color::Cyan))))
         .collect::<Vec<_>>();
@@ -439,8 +469,8 @@ fn render_dependencies(frame: &mut ratatui::Frame<'_>, app: &mut App, area: Rect
     frame.render_widget(readme_paragraph, right_chunks[1]);
 
     let content_height = app.local_readme.lines().count().saturating_sub(1) as u16;
-    let mut scrollbar_state = ScrollbarState::new(content_height as usize)
-        .position(app.detail_readme_scroll as usize);
+    let mut scrollbar_state =
+        ScrollbarState::new(content_height as usize).position(app.detail_readme_scroll as usize);
     frame.render_stateful_widget(
         Scrollbar::new(ScrollbarOrientation::VerticalRight),
         right_chunks[1],
@@ -472,62 +502,231 @@ fn selected_detail(app: &App) -> String {
     detail
 }
 
-fn render_graph(frame: &mut ratatui::Frame<'_>, app: &App, area: Rect) {
-    let mut lines = Vec::new();
-    lines.push(app.package_name.clone());
+struct Canvas {
+    grid: Vec<Vec<char>>,
+    width: usize,
+    height: usize,
+}
 
-    let direct_count = app
-        .rows
-        .iter()
-        .filter(|row| !matches!(row.kind, DependencyKind::Transitive))
-        .count();
-    for (index, row) in app
-        .rows
-        .iter()
-        .filter(|row| !matches!(row.kind, DependencyKind::Transitive))
-        .enumerate()
-    {
-        let prefix = if index + 1 == direct_count {
-            "`--"
-        } else {
-            "|--"
-        };
-        lines.push(format!("{prefix} {} ({})", row.name, kind_label(&row.kind)));
+impl Canvas {
+    fn new(width: usize, height: usize) -> Self {
+        Self {
+            grid: vec![vec![' '; width]; height],
+            width,
+            height,
+        }
     }
+
+    fn write(&mut self, x: usize, y: usize, s: &str) {
+        if y >= self.height {
+            return;
+        }
+        for (i, c) in s.chars().enumerate() {
+            if x + i < self.width {
+                self.grid[y][x + i] = c;
+            }
+        }
+    }
+
+    fn to_string(&self) -> String {
+        self.grid
+            .iter()
+            .map(|row| row.iter().collect::<String>())
+            .map(|s| s.trim_end().to_string())
+            .filter(|s| !s.is_empty())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+}
+
+fn draw_root_box(
+    canvas: &mut Canvas,
+    x: usize,
+    y: usize,
+    name: &str,
+    has_children: bool,
+) -> (usize, usize) {
+    let name_len = name.chars().count();
+    let w = name_len.max(10) + 4;
+    let top = format!("┌{}┐", "─".repeat(w));
+    let empty = format!("│{}│", " ".repeat(w));
+
+    let pad_left = (w - name_len) / 2;
+    let pad_right = w - name_len - pad_left;
+    let text = format!(
+        "│{}{}{}│",
+        " ".repeat(pad_left),
+        name,
+        " ".repeat(pad_right)
+    );
+
+    let mid = w / 2;
+    let bottom = if has_children {
+        format!("└{}┬{}┘", "─".repeat(mid), "─".repeat(w - mid - 1))
+    } else {
+        format!("└{}┘", "─".repeat(w))
+    };
+
+    canvas.write(x, y, &top);
+    canvas.write(x, y + 1, &empty);
+    canvas.write(x, y + 2, &text);
+    canvas.write(x, y + 3, &empty);
+    canvas.write(x, y + 4, &bottom);
+
+    (x + mid + 1, y + 4)
+}
+
+fn draw_dep_box(
+    canvas: &mut Canvas,
+    x: usize,
+    y: usize,
+    kind: &str,
+    version: &str,
+    name: &str,
+) -> (usize, usize) {
+    let kind_len = kind.chars().count();
+    let ver_len = version.chars().count();
+    let name_len = name.chars().count();
+
+    let w1 = kind_len.max(ver_len) + 2;
+    let w2 = name_len + 2;
+
+    let top = format!("┌{}┬{}┐", "─".repeat(w1), "─".repeat(w2));
+
+    let pad_kind_l = (w1 - kind_len) / 2;
+    let pad_kind_r = w1 - kind_len - pad_kind_l;
+    let line1 = format!(
+        "│{}{}{}│{}│",
+        " ".repeat(pad_kind_l),
+        kind,
+        " ".repeat(pad_kind_r),
+        " ".repeat(w2)
+    );
+
+    let line2 = format!(
+        "├{}┤ {}{}│",
+        "─".repeat(w1),
+        name,
+        " ".repeat(w2 - name_len - 1)
+    );
+
+    let pad_ver_l = (w1 - ver_len) / 2;
+    let pad_ver_r = w1 - ver_len - pad_ver_l;
+    let line3 = format!(
+        "│{}{}{}│{}│",
+        " ".repeat(pad_ver_l),
+        version,
+        " ".repeat(pad_ver_r),
+        " ".repeat(w2)
+    );
+
+    let bottom = format!("└{}┴{}┘", "─".repeat(w1), "─".repeat(w2));
+
+    canvas.write(x, y, &top);
+    canvas.write(x, y + 1, &line1);
+    canvas.write(x, y + 2, &line2);
+    canvas.write(x, y + 3, &line3);
+    canvas.write(x, y + 4, &bottom);
+
+    (x, y + 2)
+}
+
+fn render_graph(frame: &mut ratatui::Frame<'_>, app: &App, area: Rect) {
+    let mut deps = Vec::new();
+
+    let direct: Vec<_> = app
+        .rows
+        .iter()
+        .filter(|row| !matches!(row.kind, DependencyKind::Transitive))
+        .collect();
+    deps.extend(direct);
 
     let transitive: Vec<_> = app
         .rows
         .iter()
         .filter(|row| matches!(row.kind, DependencyKind::Transitive))
         .collect();
-    if !transitive.is_empty() {
-        lines.push("`-- transitive modules from quiver.lock".to_string());
-        for row in transitive {
-            lines.push(format!("    |-- {} ({})", row.name, row.requested));
+    deps.extend(transitive);
+
+    let height = 5 + (deps.len().max(1)) * 6 + 2;
+    let width = 200;
+    let mut canvas = Canvas::new(width, height);
+
+    let package_name = if app.package_name.is_empty() {
+        "No Project"
+    } else {
+        &app.package_name
+    };
+    let (root_px, root_py) = draw_root_box(&mut canvas, 4, 1, package_name, !deps.is_empty());
+
+    let spine_x = root_px;
+    let mut current_y = root_py;
+
+    for (i, row) in deps.iter().enumerate() {
+        let is_last = i == deps.len() - 1;
+        let dep_y = 6 + i * 6 + 1;
+        let dep_x = spine_x + 8;
+
+        let version = if let Some(tag) = &row.locked_tag {
+            tag.clone()
+        } else if let Some(rev) = &row.locked_rev {
+            short_rev(rev).to_string()
+        } else {
+            row.requested.clone()
+        };
+
+        let (in_x, in_y) = draw_dep_box(
+            &mut canvas,
+            dep_x,
+            dep_y,
+            kind_label(&row.kind),
+            &version,
+            &row.name,
+        );
+
+        for y in (current_y + 1)..=in_y {
+            let ch = if y == in_y {
+                if is_last { '└' } else { '├' }
+            } else {
+                '│'
+            };
+            canvas.write(spine_x, y, &ch.to_string());
         }
+
+        for x in (spine_x + 1)..(in_x - 1) {
+            canvas.write(x, in_y, "─");
+        }
+
+        canvas.write(in_x - 1, in_y, "►");
+
+        current_y = in_y;
     }
 
-    if lines.len() == 1 {
-        lines.push("`-- no dependencies".to_string());
-    }
+    let text = canvas.to_string();
 
     frame.render_widget(
-        Paragraph::new(lines.join("\n"))
+        Paragraph::new(text)
             .block(
                 Block::default()
                     .title("Dependency Graph")
                     .borders(Borders::ALL),
             )
+            .scroll((app.graph_scroll, 0))
             .wrap(Wrap { trim: false }),
         area,
     );
 }
 
 fn render_search(frame: &mut ratatui::Frame<'_>, app: &mut App, area: Rect) {
-    let chunks = Layout::default()
+    let horizontal_chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(area);
+
+    let left_chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Length(3), Constraint::Min(5)])
-        .split(area);
+        .split(horizontal_chunks[0]);
 
     let url = if app.readme_url.is_empty() {
         "No repository loaded".to_string()
@@ -535,24 +734,48 @@ fn render_search(frame: &mut ratatui::Frame<'_>, app: &mut App, area: Rect) {
         app.readme_url.clone()
     };
     frame.render_widget(
-        Paragraph::new(url).block(Block::default().title("Repository").borders(Borders::ALL)),
-        chunks[0],
+        Paragraph::new(url).block(
+            Block::default()
+                .title("GitHub Repository")
+                .borders(Borders::ALL),
+        ),
+        left_chunks[0],
     );
 
     let paragraph = Paragraph::new(tui_markdown::from_str(app.readme.as_str()))
         .block(Block::default().title("README").borders(Borders::ALL))
         .scroll((app.readme_scroll, 0))
         .wrap(Wrap { trim: false });
-    frame.render_widget(paragraph, chunks[1]);
+    frame.render_widget(paragraph, left_chunks[1]);
 
     let content_height = app.readme.lines().count().saturating_sub(1) as u16;
     let mut scrollbar_state =
         ScrollbarState::new(content_height as usize).position(app.readme_scroll as usize);
     frame.render_stateful_widget(
         Scrollbar::new(ScrollbarOrientation::VerticalRight),
-        chunks[1],
+        left_chunks[1],
         &mut scrollbar_state,
     );
+
+    let items: Vec<ListItem> = BUILTIN_PLUGINS
+        .iter()
+        .map(|p| ListItem::new(Line::from(p.to_string())))
+        .collect();
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .title("Built-in Plugins")
+                .borders(Borders::ALL),
+        )
+        .highlight_symbol("> ")
+        .highlight_style(
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        );
+    let mut list_state = ListState::default();
+    list_state.select(Some(app.search_selected));
+    frame.render_stateful_widget(list, horizontal_chunks[1], &mut list_state);
 }
 
 fn render_footer(frame: &mut ratatui::Frame<'_>, app: &App, area: Rect) {
@@ -562,7 +785,7 @@ fn render_footer(frame: &mut ratatui::Frame<'_>, app: &App, area: Rect) {
         }
         Tab::Graph => "q quit | tab switch | d dependencies | a add URL",
         Tab::Search => {
-            "q quit | tab switch | a paste URL | m add module | p add plugin | j/k scroll"
+            "q quit | tab switch | j/k select plugin | Enter add plugin | a paste URL | m add repo module | p add repo plugin | PgUp/PgDn scroll README"
         }
     };
     let text = format!("{keys}\n{}", app.status);
@@ -614,7 +837,11 @@ fn handle_normal_key(app: &mut App, code: KeyCode, modifiers: KeyModifiers) {
         KeyCode::Char('s') => app.tab = Tab::Search,
         KeyCode::Down | KeyCode::Char('j') => {
             if app.tab == Tab::Search {
-                app.readme_scroll = app.readme_scroll.saturating_add(1);
+                if app.search_selected + 1 < BUILTIN_PLUGINS.len() {
+                    app.search_selected += 1;
+                }
+            } else if app.tab == Tab::Graph {
+                app.graph_scroll = app.graph_scroll.saturating_add(1);
             } else if app.selected + 1 < app.rows.len() {
                 app.selected += 1;
                 reload_selected_dist_info(app);
@@ -622,7 +849,11 @@ fn handle_normal_key(app: &mut App, code: KeyCode, modifiers: KeyModifiers) {
         }
         KeyCode::Up | KeyCode::Char('k') => {
             if app.tab == Tab::Search {
-                app.readme_scroll = app.readme_scroll.saturating_sub(1);
+                if app.search_selected > 0 {
+                    app.search_selected -= 1;
+                }
+            } else if app.tab == Tab::Graph {
+                app.graph_scroll = app.graph_scroll.saturating_sub(1);
             } else if app.selected > 0 {
                 app.selected -= 1;
                 reload_selected_dist_info(app);
@@ -633,6 +864,8 @@ fn handle_normal_key(app: &mut App, code: KeyCode, modifiers: KeyModifiers) {
                 app.detail_readme_scroll = app.detail_readme_scroll.saturating_add(10);
             } else if app.tab == Tab::Search {
                 app.readme_scroll = app.readme_scroll.saturating_add(10);
+            } else if app.tab == Tab::Graph {
+                app.graph_scroll = app.graph_scroll.saturating_add(10);
             }
         }
         KeyCode::PageUp => {
@@ -640,6 +873,8 @@ fn handle_normal_key(app: &mut App, code: KeyCode, modifiers: KeyModifiers) {
                 app.detail_readme_scroll = app.detail_readme_scroll.saturating_sub(10);
             } else if app.tab == Tab::Search {
                 app.readme_scroll = app.readme_scroll.saturating_sub(10);
+            } else if app.tab == Tab::Graph {
+                app.graph_scroll = app.graph_scroll.saturating_sub(10);
             }
         }
         KeyCode::Home => {
@@ -647,6 +882,8 @@ fn handle_normal_key(app: &mut App, code: KeyCode, modifiers: KeyModifiers) {
                 app.readme_scroll = 0;
             } else if app.tab == Tab::Dependencies {
                 app.detail_readme_scroll = 0;
+            } else if app.tab == Tab::Graph {
+                app.graph_scroll = 0;
             } else {
                 app.selected = 0;
             }
@@ -676,6 +913,13 @@ fn handle_normal_key(app: &mut App, code: KeyCode, modifiers: KeyModifiers) {
             app.action = Some(TuiAction::AddPlugin {
                 url: app.readme_url.clone(),
             });
+        }
+        KeyCode::Enter => {
+            if app.tab == Tab::Search && app.can_manage() {
+                app.action = Some(TuiAction::AddPlugin {
+                    url: BUILTIN_PLUGINS[app.search_selected].to_string(),
+                });
+            }
         }
         _ => {}
     }
@@ -839,7 +1083,11 @@ fn dist_info_path(project_dir: &Path, row: &DependencyRow) -> Option<PathBuf> {
 }
 
 fn read_local_readme(dist_info_dir: &Path) -> String {
-    for entry in std::fs::read_dir(dist_info_dir).into_iter().flatten().flatten() {
+    for entry in std::fs::read_dir(dist_info_dir)
+        .into_iter()
+        .flatten()
+        .flatten()
+    {
         let name = entry.file_name().to_string_lossy().to_lowercase();
         let base = name.split('.').next().unwrap_or(&name);
         if base == "readme" {
@@ -864,7 +1112,11 @@ fn read_local_license(dist_info_dir: &Path) -> String {
         }
     }
 
-    for entry in std::fs::read_dir(dist_info_dir).into_iter().flatten().flatten() {
+    for entry in std::fs::read_dir(dist_info_dir)
+        .into_iter()
+        .flatten()
+        .flatten()
+    {
         let name = entry.file_name().to_string_lossy().to_lowercase();
         let base = name.split('.').next().unwrap_or(&name);
         if matches!(base, "license" | "licenses" | "copying") {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crossterm::{
-    event::{self, Event, KeyCode, KeyEventKind, KeyModifiers},
+    event::{self, Event, KeyCode, KeyEventKind, KeyModifiers, EnableMouseCapture, DisableMouseCapture, MouseEventKind},
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
@@ -61,6 +61,7 @@ struct DependencyRow {
     git: String,
     requested: String,
     locked_rev: Option<String>,
+    locked_tag: Option<String>,
     checksum: Option<String>,
 }
 
@@ -72,6 +73,9 @@ struct App {
     tab: Tab,
     selected: usize,
     readme_scroll: u16,
+    detail_readme_scroll: u16,
+    local_readme: String,
+    local_license: String,
     status: String,
     input: String,
     readme_url: String,
@@ -92,7 +96,7 @@ pub fn run(cwd: &Path) -> Result<Option<TuiAction>> {
 
     enable_raw_mode()?;
     let mut stderr = io::stderr();
-    execute!(stderr, EnterAlternateScreen)?;
+    execute!(stderr, EnterAlternateScreen, EnableMouseCapture)?;
     let backend = CrosstermBackend::new(stderr);
     let mut terminal = Terminal::new(backend)?;
 
@@ -100,14 +104,32 @@ pub fn run(cwd: &Path) -> Result<Option<TuiAction>> {
         loop {
             terminal.draw(|frame| render(frame, &mut app))?;
 
-            if let Event::Key(key) = event::read()? {
-                if key.kind != KeyEventKind::Press {
-                    continue;
+            match event::read()? {
+                Event::Key(key) => {
+                    if key.kind != KeyEventKind::Press {
+                        continue;
+                    }
+                    handle_key(&mut app, key.code, key.modifiers);
                 }
-                handle_key(&mut app, key.code, key.modifiers);
-                if app.quit || app.action.is_some() {
-                    break;
-                }
+                Event::Mouse(mouse) => match mouse.kind {
+                    MouseEventKind::ScrollDown if app.tab == Tab::Dependencies => {
+                        app.detail_readme_scroll = app.detail_readme_scroll.saturating_add(3);
+                    }
+                    MouseEventKind::ScrollUp if app.tab == Tab::Dependencies => {
+                        app.detail_readme_scroll = app.detail_readme_scroll.saturating_sub(3);
+                    }
+                    MouseEventKind::ScrollDown if app.tab == Tab::Search => {
+                        app.readme_scroll = app.readme_scroll.saturating_add(3);
+                    }
+                    MouseEventKind::ScrollUp if app.tab == Tab::Search => {
+                        app.readme_scroll = app.readme_scroll.saturating_sub(3);
+                    }
+                    _ => {}
+                },
+                _ => continue,
+            }
+            if app.quit || app.action.is_some() {
+                break;
             }
         }
 
@@ -116,7 +138,7 @@ pub fn run(cwd: &Path) -> Result<Option<TuiAction>> {
 
     let cleanup_result = (|| -> io::Result<()> {
         disable_raw_mode()?;
-        execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+        execute!(terminal.backend_mut(), LeaveAlternateScreen, DisableMouseCapture)?;
         terminal.show_cursor()?;
         Ok(())
     })();
@@ -139,6 +161,9 @@ impl App {
                 tab: Tab::Dependencies,
                 selected: 0,
                 readme_scroll: 0,
+                detail_readme_scroll: 0,
+                local_readme: String::new(),
+                local_license: String::new(),
                 status: "Run qv init to create nupackage.toml, or q to quit.".to_string(),
                 input: String::new(),
                 readme_url: String::new(),
@@ -159,6 +184,11 @@ impl App {
                 .to_string()
         };
 
+        let (local_readme, local_license) = rows
+            .first()
+            .map(|row| load_dist_info_for_row(&project_dir, row))
+            .unwrap_or_default();
+
         Ok(Self {
             project_dir: Some(project_dir),
             package_name: manifest.package.name,
@@ -167,6 +197,9 @@ impl App {
             tab: Tab::Dependencies,
             selected: 0,
             readme_scroll: 0,
+            detail_readme_scroll: 0,
+            local_readme,
+            local_license,
             status,
             input: String::new(),
             readme_url: String::new(),
@@ -218,6 +251,7 @@ fn dependency_rows(manifest: &Manifest, lockfile: Option<&Lockfile>) -> Vec<Depe
             git: spec.git.clone(),
             requested: requested_ref(&spec.tag, &spec.rev, &spec.branch),
             locked_rev: locked.map(|p| p.rev.clone()),
+            locked_tag: locked.and_then(|p| p.tag.clone()),
             checksum: locked.map(|p| p.sha256.clone()),
         });
     }
@@ -237,6 +271,7 @@ fn dependency_rows(manifest: &Manifest, lockfile: Option<&Lockfile>) -> Vec<Depe
             },
             requested: requested_ref(&spec.tag, &spec.rev, &spec.branch),
             locked_rev: locked.map(|p| p.rev.clone()),
+            locked_tag: locked.and_then(|p| p.tag.clone()),
             checksum: locked.map(|p| p.sha256.clone()),
         });
     }
@@ -258,6 +293,7 @@ fn dependency_rows(manifest: &Manifest, lockfile: Option<&Lockfile>) -> Vec<Depe
                 git: package.git.clone(),
                 requested: package.tag.clone().unwrap_or_else(|| "locked".to_string()),
                 locked_rev: Some(package.rev.clone()),
+                locked_tag: package.tag.clone(),
                 checksum: Some(package.sha256.clone()),
             });
         }
@@ -372,12 +408,43 @@ fn render_dependencies(frame: &mut ratatui::Frame<'_>, app: &mut App, area: Rect
     }
     frame.render_stateful_widget(list, chunks[0], &mut list_state);
 
+    // Right pane: split into details (top) and README (bottom)
+    let right_chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(9), Constraint::Min(4)])
+        .split(chunks[1]);
+
     let detail = selected_detail(app);
     frame.render_widget(
         Paragraph::new(detail)
             .block(Block::default().title("Details").borders(Borders::ALL))
             .wrap(Wrap { trim: false }),
-        chunks[1],
+        right_chunks[0],
+    );
+
+    let readme_content = if app.local_readme.is_empty() {
+        if app.selected_row().is_some_and(|r| r.locked_rev.is_some()) {
+            "No README found in dist-info."
+        } else {
+            "Not installed."
+        }
+    } else {
+        app.local_readme.as_str()
+    };
+
+    let readme_paragraph = Paragraph::new(tui_markdown::from_str(readme_content))
+        .block(Block::default().title("README").borders(Borders::ALL))
+        .scroll((app.detail_readme_scroll, 0))
+        .wrap(Wrap { trim: false });
+    frame.render_widget(readme_paragraph, right_chunks[1]);
+
+    let content_height = app.local_readme.lines().count().saturating_sub(1) as u16;
+    let mut scrollbar_state = ScrollbarState::new(content_height as usize)
+        .position(app.detail_readme_scroll as usize);
+    frame.render_stateful_widget(
+        Scrollbar::new(ScrollbarOrientation::VerticalRight),
+        right_chunks[1],
+        &mut scrollbar_state,
     );
 }
 
@@ -389,6 +456,9 @@ fn selected_detail(app: &App) -> String {
     let mut detail = String::new();
     detail.push_str(&format!("name: {}\n", row.name));
     detail.push_str(&format!("kind: {}\n", kind_label(&row.kind)));
+    if !app.local_license.is_empty() {
+        detail.push_str(&format!("license: {}\n", app.local_license));
+    }
     detail.push_str(&format!("source: {}\n", row.git));
     detail.push_str(&format!("requested: {}\n", row.requested));
     if let Some(rev) = &row.locked_rev {
@@ -469,7 +539,7 @@ fn render_search(frame: &mut ratatui::Frame<'_>, app: &mut App, area: Rect) {
         chunks[0],
     );
 
-    let paragraph = Paragraph::new(app.readme.as_str())
+    let paragraph = Paragraph::new(tui_markdown::from_str(app.readme.as_str()))
         .block(Block::default().title("README").borders(Borders::ALL))
         .scroll((app.readme_scroll, 0))
         .wrap(Wrap { trim: false });
@@ -488,7 +558,7 @@ fn render_search(frame: &mut ratatui::Frame<'_>, app: &mut App, area: Rect) {
 fn render_footer(frame: &mut ratatui::Frame<'_>, app: &App, area: Rect) {
     let keys = match app.tab {
         Tab::Dependencies => {
-            "q quit | tab switch | i install | u update | r remove | a add URL | g graph"
+            "q quit | tab switch | j/k select | PgUp/PgDn scroll | i install | u update | r remove | a add"
         }
         Tab::Graph => "q quit | tab switch | d dependencies | a add URL",
         Tab::Search => {
@@ -547,18 +617,36 @@ fn handle_normal_key(app: &mut App, code: KeyCode, modifiers: KeyModifiers) {
                 app.readme_scroll = app.readme_scroll.saturating_add(1);
             } else if app.selected + 1 < app.rows.len() {
                 app.selected += 1;
+                reload_selected_dist_info(app);
             }
         }
         KeyCode::Up | KeyCode::Char('k') => {
             if app.tab == Tab::Search {
                 app.readme_scroll = app.readme_scroll.saturating_sub(1);
-            } else {
-                app.selected = app.selected.saturating_sub(1);
+            } else if app.selected > 0 {
+                app.selected -= 1;
+                reload_selected_dist_info(app);
+            }
+        }
+        KeyCode::PageDown => {
+            if app.tab == Tab::Dependencies {
+                app.detail_readme_scroll = app.detail_readme_scroll.saturating_add(10);
+            } else if app.tab == Tab::Search {
+                app.readme_scroll = app.readme_scroll.saturating_add(10);
+            }
+        }
+        KeyCode::PageUp => {
+            if app.tab == Tab::Dependencies {
+                app.detail_readme_scroll = app.detail_readme_scroll.saturating_sub(10);
+            } else if app.tab == Tab::Search {
+                app.readme_scroll = app.readme_scroll.saturating_sub(10);
             }
         }
         KeyCode::Home => {
             if app.tab == Tab::Search {
                 app.readme_scroll = 0;
+            } else if app.tab == Tab::Dependencies {
+                app.detail_readme_scroll = 0;
             } else {
                 app.selected = 0;
             }
@@ -699,6 +787,109 @@ fn short_rev(rev: &str) -> &str {
     rev.get(..12).unwrap_or(rev)
 }
 
+fn reload_selected_dist_info(app: &mut App) {
+    if let (Some(project_dir), Some(row)) = (&app.project_dir, app.selected_row()) {
+        let (readme, license) = load_dist_info_for_row(project_dir, row);
+        app.local_readme = readme;
+        app.local_license = license;
+        app.detail_readme_scroll = 0;
+    } else {
+        app.local_readme.clear();
+        app.local_license.clear();
+        app.detail_readme_scroll = 0;
+    }
+}
+
+fn load_dist_info_for_row(project_dir: &Path, row: &DependencyRow) -> (String, String) {
+    let mut readme = String::new();
+    let mut license = String::new();
+
+    if let Some(dist_info) = dist_info_path(project_dir, row) {
+        readme = read_local_readme(&dist_info);
+        license = read_local_license(&dist_info);
+    }
+
+    (readme, license)
+}
+
+fn dist_info_path(project_dir: &Path, row: &DependencyRow) -> Option<PathBuf> {
+    let rev = row.locked_rev.as_ref()?;
+    let tag = row
+        .locked_tag
+        .as_deref()
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+        .unwrap_or(&rev[..12.min(rev.len())]);
+
+    let mut version = String::with_capacity(tag.len());
+    for ch in tag.chars() {
+        if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-') {
+            version.push(ch);
+        } else {
+            version.push('_');
+        }
+    }
+
+    if version.is_empty() {
+        version.push_str("unknown");
+    }
+
+    let dir_name = format!("{}-{version}.dist-info", row.name);
+    Some(project_dir.join(".nu-env").join("modules").join(dir_name))
+}
+
+fn read_local_readme(dist_info_dir: &Path) -> String {
+    for entry in std::fs::read_dir(dist_info_dir).into_iter().flatten().flatten() {
+        let name = entry.file_name().to_string_lossy().to_lowercase();
+        let base = name.split('.').next().unwrap_or(&name);
+        if base == "readme" {
+            if let Ok(content) = std::fs::read_to_string(entry.path()) {
+                return content;
+            }
+        }
+    }
+    String::new()
+}
+
+fn read_local_license(dist_info_dir: &Path) -> String {
+    let nupackage = dist_info_dir.join("nupackage.toml");
+    if let Ok(content) = std::fs::read_to_string(&nupackage) {
+        if let Ok(manifest) = crate::manifest::Manifest::from_str(&content) {
+            if let Some(license) = manifest.package.license {
+                let trimmed = license.trim();
+                if !trimmed.is_empty() {
+                    return trimmed.to_string();
+                }
+            }
+        }
+    }
+
+    for entry in std::fs::read_dir(dist_info_dir).into_iter().flatten().flatten() {
+        let name = entry.file_name().to_string_lossy().to_lowercase();
+        let base = name.split('.').next().unwrap_or(&name);
+        if matches!(base, "license" | "licenses" | "copying") {
+            if let Ok(content) = std::fs::read_to_string(entry.path()) {
+                let upper = content.to_ascii_uppercase();
+                if upper.contains("MIT") {
+                    return "MIT".to_string();
+                }
+                if upper.contains("APACHE") {
+                    return "Apache-2.0".to_string();
+                }
+                if upper.contains("GPL") {
+                    return "GPL".to_string();
+                }
+                if upper.contains("BSD") {
+                    return "BSD".to_string();
+                }
+                return "Unknown".to_string();
+            }
+        }
+    }
+
+    String::new()
+}
+
 fn next_tab(tab: Tab) -> Tab {
     match tab {
         Tab::Dependencies => Tab::Graph,
@@ -758,5 +949,61 @@ mod tests {
     #[test]
     fn rejects_non_github_url() {
         assert_eq!(parse_github_owner_repo("https://example.com/a/b"), None);
+    }
+
+    #[test]
+    fn test_dist_info_path() {
+        let row = DependencyRow {
+            name: "nu-salesforce".to_string(),
+            kind: DependencyKind::Module,
+            git: "test".to_string(),
+            requested: "test".to_string(),
+            locked_rev: Some("0123456789abcdef".to_string()),
+            locked_tag: Some("v0.3.0".to_string()),
+            checksum: None,
+        };
+        let path = dist_info_path(Path::new("/project"), &row).unwrap();
+        assert_eq!(
+            path,
+            PathBuf::from("/project/.nu-env/modules/nu-salesforce-v0.3.0.dist-info")
+        );
+
+        let row_no_tag = DependencyRow {
+            name: "nu-salesforce".to_string(),
+            kind: DependencyKind::Module,
+            git: "test".to_string(),
+            requested: "test".to_string(),
+            locked_rev: Some("0123456789abcdef".to_string()),
+            locked_tag: None,
+            checksum: None,
+        };
+        let path_no_tag = dist_info_path(Path::new("/project"), &row_no_tag).unwrap();
+        assert_eq!(
+            path_no_tag,
+            PathBuf::from("/project/.nu-env/modules/nu-salesforce-0123456789ab.dist-info")
+        );
+    }
+
+    #[test]
+    fn test_read_local_license() {
+        let temp_dir = std::env::temp_dir().join("quiver_test_license");
+        let _ = std::fs::remove_dir_all(&temp_dir);
+        std::fs::create_dir_all(&temp_dir).unwrap();
+
+        std::fs::write(temp_dir.join("LICENSE"), "This is an MIT license.\n").unwrap();
+        assert_eq!(read_local_license(&temp_dir), "MIT");
+
+        std::fs::write(
+            temp_dir.join("nupackage.toml"),
+            r#"[package]
+name = "test"
+version = "0.1.0"
+license = "Apache-2.0"
+"#,
+        )
+        .unwrap();
+        assert_eq!(read_local_license(&temp_dir), "Apache-2.0");
+
+        let _ = std::fs::remove_dir_all(&temp_dir);
     }
 }


### PR DESCRIPTION
## Added

- `qv` now launches a TUI where you can manage dependencies for your Quiver project. It includes a dependency graph, README and info viewer for installed dependencies, and an interactive mode to view dependency README's from github before adding them.
- `qv lsp` now uses a Ratatui/Crossterm interactive picker, so editor selection works on Windows too.

## Fixed

- Release builds now vendor libgit2 through the `git2` crate, avoiding failures from missing or stale system libgit2 installations.

