### PR TITLE
Tui Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Unreleased
 
+## Added
+
+- You can now run commands from within the TUI and the results will be shown in the log at the bottom (previously running a command like adding a dep would close the TUI). The command log is hidden by default, can be toggled with `/`, and is shown automatically while TUI-triggered commands run.
+- The TUI Add flow now lets repository modules and plugins choose how to pin the dependency before adding it: auto-detect, tag, branch, or revision.
+- The TUI now supports clickable header tabs for switching between Dependencies, Graph, and Add.
+
+## Changed
+
+- TUI README rendering now uses `leaves` for true Markdown rendering and syntax highlighting for code blocks.
+- TUI panes and dialogs now use rounded borders, and dependency detail labels are styled for easier scanning.
+- The TUI Add page now gives the repository README preview the main pane instead of splitting it with the built-in plugin list.
+- The TUI Add tab now opens built-in plugin selection in a focused dialog via `b`.
+- TUI remove confirmation now accepts Enter to confirm and Esc to cancel.
+- TUI mouse movement and button release no longer steal focus; focus changes on click or scroll instead.
+
 # Version 0.6.0 (2026-05-05)
 
 ## Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -776,8 +776,8 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leaves"
-version = "0.1.0"
-source = "git+https://github.com/freepicheep/leaves.git?branch=main#e2011771332425dbfb7154d034f83ff2f334d86c"
+version = "0.1.1"
+source = "git+https://github.com/freepicheep/leaves.git?branch=main#79c8a9803c8a91c7c0b0c99665eb195c926c0b54"
 dependencies = [
  "mmdflux",
  "pulldown-cmark",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,19 +24,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "ansi-to-tui"
-version = "8.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42366bb9d958f042bf58f0a85e1b2d091997c1257ca49bddd7e4827aadc65fd"
-dependencies = [
- "nom 8.0.0",
- "ratatui-core",
- "simdutf8",
- "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,7 +59,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -83,29 +70,8 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
-name = "atomic"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
-name = "autocfg"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
@@ -121,27 +87,6 @@ checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -165,10 +110,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
-name = "bytemuck"
-version = "1.25.0"
+name = "cassowary"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "castaway"
@@ -196,12 +141,6 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
@@ -234,7 +173,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -251,9 +190,9 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "compact_str"
-version = "0.9.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -272,8 +211,8 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width",
- "windows-sys",
+ "unicode-width 0.2.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -305,17 +244,33 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "crossterm_winapi",
  "derive_more",
  "document-features",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -341,16 +296,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "csscolorparser"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
-dependencies = [
- "lab",
- "phf",
-]
-
-[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,7 +315,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -381,14 +326,8 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
-
-[[package]]
-name = "deltae"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
 name = "deranged"
@@ -418,14 +357,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn",
 ]
-
-[[package]]
-name = "diff"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -455,7 +388,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -466,7 +399,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -503,37 +436,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
-]
-
-[[package]]
-name = "euclid"
-version = "0.22.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "fancy-regex"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
-dependencies = [
- "bit-set",
- "regex",
-]
-
-[[package]]
-name = "filedescriptor"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
-dependencies = [
- "libc",
- "thiserror 1.0.69",
- "winapi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -552,18 +455,6 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "finl_unicode"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
-
-[[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -589,60 +480,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
-name = "foldhash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "futures-task"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
-
-[[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
-
-[[package]]
-name = "futures-util"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
-dependencies = [
- "futures-core",
- "futures-macro",
- "futures-task",
- "pin-project-lite",
- "slab",
 ]
 
 [[package]]
@@ -661,7 +504,7 @@ version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -683,21 +526,8 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi 5.3.0",
+ "r-efi",
  "wasip2",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -706,7 +536,7 @@ version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "libc",
  "libgit2-sys",
  "log",
@@ -716,18 +546,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash 0.1.5",
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
 ]
 
 [[package]]
@@ -735,11 +561,6 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash 0.2.0",
-]
 
 [[package]]
 name = "heck"
@@ -835,12 +656,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,8 +690,6 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -887,7 +700,7 @@ checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
  "console",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.0",
  "unit-prefix",
  "web-time",
 ]
@@ -911,7 +724,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -922,9 +735,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.14.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -956,33 +769,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "kasuari"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
-dependencies = [
- "hashbrown 0.16.1",
- "portable-atomic",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "lab"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
+name = "leaves"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+source = "git+https://github.com/freepicheep/leaves.git?branch=main#e2011771332425dbfb7154d034f83ff2f334d86c"
+dependencies = [
+ "mmdflux",
+ "pulldown-cmark",
+ "ratatui",
+ "syntect",
+ "unicode-width 0.1.14",
+ "unicodeit",
+]
 
 [[package]]
 name = "libc"
@@ -1010,7 +813,7 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "libc",
  "plain",
  "redox_syscall 0.7.3",
@@ -1043,19 +846,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "line-clipping"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
-dependencies = [
- "bitflags 2.11.0",
-]
-
-[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1092,11 +892,11 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1111,13 +911,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "mac_address"
-version = "1.1.8"
+name = "matchers"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "nix",
- "winapi",
+ "regex-automata",
 ]
 
 [[package]]
@@ -1125,27 +924,6 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "memmem"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1166,39 +944,34 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
-name = "nix"
-version = "0.29.0"
+name = "mmdflux"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+checksum = "bbe0fc0a189f8195f70426e89bba6860c4b0522e153803da020266a6c9b2c588"
 dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "cfg_aliases",
+ "clap",
  "libc",
- "memoffset",
+ "pest",
+ "pest_derive",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+ "tracing-subscriber",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
-name = "nom"
-version = "7.1.3"
+name = "nu-ansi-term"
+version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "memchr",
- "minimal-lexical",
-]
-
-[[package]]
-name = "nom"
-version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
-dependencies = [
- "memchr",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1206,35 +979,6 @@ name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
-
-[[package]]
-name = "num-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "once_cell"
@@ -1254,7 +998,7 @@ version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "libc",
  "once_cell",
  "onig_sys",
@@ -1295,15 +1039,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
-name = "ordered-float"
-version = "4.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1325,6 +1060,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -1362,7 +1103,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1373,58 +1114,6 @@ checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
  "sha2",
-]
-
-[[package]]
-name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_macros",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
-dependencies = [
- "phf_generator",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared",
- "rand",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator",
- "phf_shared",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
 ]
 
 [[package]]
@@ -1480,35 +1169,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "pretty_assertions"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
-dependencies = [
- "diff",
- "yansi",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
-dependencies = [
- "toml_edit",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1519,11 +1179,11 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.13.3"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
+checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "getopts",
  "memchr",
  "pulldown-cmark-escape",
@@ -1551,21 +1211,22 @@ version = "0.6.0"
 dependencies = [
  "clap",
  "console",
- "crossterm",
+ "crossterm 0.29.0",
  "dirs",
  "flate2",
  "git2",
  "hex",
  "indicatif",
+ "leaves",
  "ratatui",
  "semver",
  "serde",
  "serde_json",
  "sha2",
+ "syntect",
  "tar",
- "thiserror 2.0.18",
+ "thiserror",
  "toml",
- "tui-markdown",
  "walkdir",
  "xz2",
  "zip",
@@ -1587,109 +1248,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "r-efi"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
-name = "rand"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-
-[[package]]
 name = "ratatui"
-version = "0.30.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "instability",
- "ratatui-core",
- "ratatui-crossterm",
- "ratatui-macros",
- "ratatui-termwiz",
- "ratatui-widgets",
-]
-
-[[package]]
-name = "ratatui-core"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
-dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
+ "cassowary",
  "compact_str",
- "hashbrown 0.16.1",
+ "crossterm 0.28.1",
  "indoc",
+ "instability",
  "itertools",
- "kasuari",
  "lru",
+ "paste",
  "strum",
- "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
- "unicode-width",
-]
-
-[[package]]
-name = "ratatui-crossterm"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
-dependencies = [
- "cfg-if",
- "crossterm",
- "instability",
- "ratatui-core",
-]
-
-[[package]]
-name = "ratatui-macros"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
-dependencies = [
- "ratatui-core",
- "ratatui-widgets",
-]
-
-[[package]]
-name = "ratatui-termwiz"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f76fe0bd0ed4295f0321b1676732e2454024c15a35d01904ddb315afd3d545c"
-dependencies = [
- "ratatui-core",
- "termwiz",
-]
-
-[[package]]
-name = "ratatui-widgets"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
-dependencies = [
- "bitflags 2.11.0",
- "hashbrown 0.16.1",
- "indoc",
- "instability",
- "itertools",
- "line-clipping",
- "ratatui-core",
- "strum",
- "time",
- "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -1698,7 +1274,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -1707,7 +1283,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -1718,7 +1294,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -1751,41 +1327,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
-name = "relative-path"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
-
-[[package]]
-name = "rstest"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
-dependencies = [
- "futures-timer",
- "futures-util",
- "rstest_macros",
-]
-
-[[package]]
-name = "rstest_macros"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
-dependencies = [
- "cfg-if",
- "glob",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "regex",
- "relative-path",
- "rustc_version",
- "syn 2.0.117",
- "unicode-ident",
-]
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1796,15 +1337,28 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
- "windows-sys",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1867,7 +1421,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1901,6 +1455,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1947,24 +1510,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
-name = "simdutf8"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
-
-[[package]]
-name = "siphasher"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
-
-[[package]]
-name = "slab"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
-
-[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1990,34 +1535,24 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.27.2"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.27.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
+ "rustversion",
+ "syn",
 ]
 
 [[package]]
@@ -2039,7 +1574,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2058,7 +1593,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
  "walkdir",
  "yaml-rust",
 ]
@@ -2075,95 +1610,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "terminfo"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
-dependencies = [
- "fnv",
- "nom 7.1.3",
- "phf",
- "phf_codegen",
-]
-
-[[package]]
-name = "termios"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "termwiz"
-version = "0.23.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
-dependencies = [
- "anyhow",
- "base64",
- "bitflags 2.11.0",
- "fancy-regex",
- "filedescriptor",
- "finl_unicode",
- "fixedbitset",
- "hex",
- "lazy_static",
- "libc",
- "log",
- "memmem",
- "nix",
- "num-derive",
- "num-traits",
- "ordered-float",
- "pest",
- "pest_derive",
- "phf",
- "sha2",
- "signal-hook",
- "siphasher",
- "terminfo",
- "termios",
- "thiserror 1.0.69",
- "ucd-trie",
- "unicode-segmentation",
- "vtparse",
- "wezterm-bidi",
- "wezterm-blob-leases",
- "wezterm-color-types",
- "wezterm-dynamic",
- "wezterm-input-types",
- "winapi",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -2174,7 +1626,16 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -2185,9 +1646,7 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
- "libc",
  "num-conv",
- "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -2245,18 +1704,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.25.4+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "toml_parser",
- "winnow",
-]
-
-[[package]]
 name = "toml_parser"
 version = "1.0.9+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2278,19 +1725,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -2300,22 +1735,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
 ]
 
 [[package]]
-name = "tui-markdown"
-version = "0.3.7"
+name = "tracing-serde"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e766339aabad4528c3fccddf4acf03bc2b7ae6642def41e43c7af1a11f183122"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
 dependencies = [
- "ansi-to-tui",
- "itertools",
- "pretty_assertions",
- "pulldown-cmark",
- "ratatui-core",
- "rstest",
- "syntect",
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "thread_local",
  "tracing",
+ "tracing-core",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -2356,14 +1805,20 @@ checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-truncate"
-version = "2.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
 dependencies = [
  "itertools",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -2372,10 +1827,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
+name = "unicodeit"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+checksum = "1c58ef1816c0901804d0e1e4df281cd4e3d7eb12a0616fd19ec851f5a48bcf4b"
+dependencies = [
+ "aho-corasick",
+ "cfg-if",
+ "memchr",
+ "regex",
+]
 
 [[package]]
 name = "unit-prefix"
@@ -2408,16 +1869,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "uuid"
-version = "1.23.1"
+name = "valuable"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
-dependencies = [
- "atomic",
- "getrandom 0.4.2",
- "js-sys",
- "wasm-bindgen",
-]
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -2430,15 +1885,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "vtparse"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
-dependencies = [
- "utf8parse",
-]
 
 [[package]]
 name = "walkdir"
@@ -2461,15 +1907,6 @@ name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
@@ -2506,7 +1943,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -2520,40 +1957,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.11.0",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2561,78 +1964,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "wezterm-bidi"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
-dependencies = [
- "log",
- "wezterm-dynamic",
-]
-
-[[package]]
-name = "wezterm-blob-leases"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
-dependencies = [
- "getrandom 0.3.4",
- "mac_address",
- "sha2",
- "thiserror 1.0.69",
- "uuid",
-]
-
-[[package]]
-name = "wezterm-color-types"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
-dependencies = [
- "csscolorparser",
- "deltae",
- "lazy_static",
- "wezterm-dynamic",
-]
-
-[[package]]
-name = "wezterm-dynamic"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
-dependencies = [
- "log",
- "ordered-float",
- "strsim",
- "thiserror 1.0.69",
- "wezterm-dynamic-derive",
-]
-
-[[package]]
-name = "wezterm-dynamic-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "wezterm-input-types"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
-dependencies = [
- "bitflags 1.3.2",
- "euclid",
- "lazy_static",
- "serde",
- "wezterm-dynamic",
 ]
 
 [[package]]
@@ -2657,7 +1988,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2674,6 +2005,24 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -2682,101 +2031,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
 name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.11.0",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"
@@ -2791,7 +2119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -2813,12 +2141,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "yansi"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
-
-[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2837,7 +2159,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -2858,7 +2180,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -2892,7 +2214,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,10 @@ console = "0.16.2"
 flate2 = "1"
 tar = "0.4"
 xz2 = "0.1"
-ratatui = "0.30"
+ratatui = "0.29"
 crossterm = "0.29"
-tui-markdown = "0.3"
+leaves = { git = "https://github.com/freepicheep/leaves.git", branch = "main" }
+syntect = "5.2"
 
 [dependencies.git2]
 version = "0.20"

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,13 +141,24 @@ fn cmd_tui(cwd: &Path) -> Result<()> {
                 let project_dir = require_project_dir(&cwd)?;
                 cmd_remove(&project_dir, name)
             }
-            tui::TuiAction::AddModule { url } => {
+            tui::TuiAction::AddModule {
+                url,
+                tag,
+                rev,
+                branch,
+            } => {
                 let project_dir = require_project_dir(&cwd)?;
-                cmd_add(&project_dir, url, None, None, None)
+                cmd_add(&project_dir, url, tag, rev, branch)
             }
-            tui::TuiAction::AddPlugin { url } => {
+            tui::TuiAction::AddPlugin {
+                url,
+                tag,
+                rev,
+                branch,
+                bin,
+            } => {
                 let project_dir = require_project_dir(&cwd)?;
-                cmd_add_plugin(&project_dir, url, None, None, None, None)
+                cmd_add_plugin(&project_dir, url, tag, rev, branch, bin)
             }
         })
     })

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1010,28 +1010,42 @@ fn render_dependencies(frame: &mut ratatui::Frame<'_>, app: &mut App, area: Rect
     );
 }
 
-fn selected_detail(app: &App) -> String {
+fn selected_detail(app: &App) -> Vec<Line<'static>> {
     let Some(row) = app.selected_row() else {
-        return "Press a to paste a GitHub repository URL and preview its README.".to_string();
+        return vec![Line::from(
+            "Press a to paste a GitHub repository URL and preview its README.",
+        )];
     };
 
-    let mut detail = String::new();
-    detail.push_str(&format!("name: {}\n", row.name));
-    detail.push_str(&format!("kind: {}\n", kind_label(&row.kind)));
+    let mut detail = Vec::new();
+    detail.push(detail_line("name", &row.name));
+    detail.push(detail_line("kind", kind_label(&row.kind)));
     if !app.local_license.is_empty() {
-        detail.push_str(&format!("license: {}\n", app.local_license));
+        detail.push(detail_line("license", &app.local_license));
     }
-    detail.push_str(&format!("source: {}\n", row.git));
-    detail.push_str(&format!("requested: {}\n", row.requested));
+    detail.push(detail_line("source", &row.git));
+    detail.push(detail_line("requested", &row.requested));
     if let Some(rev) = &row.locked_rev {
-        detail.push_str(&format!("locked rev: {}\n", rev));
+        detail.push(detail_line("locked rev", rev));
     } else {
-        detail.push_str("locked rev: not installed\n");
+        detail.push(detail_line("locked rev", "not installed"));
     }
     if let Some(checksum) = &row.checksum {
-        detail.push_str(&format!("sha256: {}\n", checksum));
+        detail.push(detail_line("sha256", checksum));
     }
     detail
+}
+
+fn detail_line(key: &str, value: &str) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(
+            format!("{key}:"),
+            Style::default()
+                .fg(Color::Blue)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(format!(" {value}")),
+    ])
 }
 
 struct Canvas {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -42,6 +42,11 @@ const BUILTIN_PLUGINS: &[&str] = &[
     "nu_plugin_stress_internals",
 ];
 
+const LOG_PANEL_HEIGHT: u16 = 8;
+const HEADER_TAB_PADDING_LEFT: &str = " ";
+const HEADER_TAB_PADDING_RIGHT: &str = " ";
+const HEADER_TAB_DIVIDER: &str = "|";
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TuiAction {
     Install,
@@ -57,6 +62,12 @@ enum Tab {
     Graph,
     Search,
 }
+
+const HEADER_TABS: [(Tab, &str); 3] = [
+    (Tab::Dependencies, "Dependencies"),
+    (Tab::Graph, "Graph"),
+    (Tab::Search, "Add"),
+];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum InputMode {
@@ -131,6 +142,7 @@ struct App {
     logs: Vec<LogLine>,
     log_scroll: u16,
     follow_log: bool,
+    log_visible: bool,
     command_rx: Option<mpsc::Receiver<TuiCommandEvent>>,
     command_running: bool,
     pending_reload: bool,
@@ -234,6 +246,7 @@ impl App {
                 )],
                 log_scroll: 0,
                 follow_log: true,
+                log_visible: false,
                 command_rx: None,
                 command_running: false,
                 pending_reload: false,
@@ -281,6 +294,7 @@ impl App {
             logs: vec![LogLine::Plain("Logs will show here".to_string())],
             log_scroll: 0,
             follow_log: true,
+            log_visible: false,
             command_rx: None,
             command_running: false,
             pending_reload: false,
@@ -340,6 +354,17 @@ impl App {
 
     fn register_region(&mut self, region: FocusRegion, area: Rect) {
         self.regions.push((region, area));
+    }
+
+    fn set_log_visible(&mut self, visible: bool) {
+        self.log_visible = visible;
+        if !visible && self.focus == FocusRegion::CommandLog {
+            self.focus = default_focus_for_tab(self.tab);
+        }
+    }
+
+    fn toggle_log_visible(&mut self) {
+        self.set_log_visible(!self.log_visible);
     }
 }
 
@@ -440,12 +465,13 @@ fn requested_ref(tag: &Option<String>, rev: &Option<String>, branch: &Option<Str
 fn render(frame: &mut ratatui::Frame<'_>, app: &mut App) {
     app.regions.clear();
     let area = frame.area();
+    let log_height = if app.log_visible { LOG_PANEL_HEIGHT } else { 0 };
     let shell = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Length(3),
             Constraint::Min(8),
-            Constraint::Length(8),
+            Constraint::Length(log_height),
             Constraint::Length(3),
         ])
         .split(area);
@@ -460,16 +486,19 @@ fn render(frame: &mut ratatui::Frame<'_>, app: &mut App) {
         }
         Tab::Search => render_search(frame, app, shell[1]),
     }
-    render_log(frame, app, shell[2]);
-    app.register_region(FocusRegion::CommandLog, shell[2]);
+    if app.log_visible {
+        render_log(frame, app, shell[2]);
+        app.register_region(FocusRegion::CommandLog, shell[2]);
+    }
     render_footer(frame, app, shell[3]);
     app.register_region(FocusRegion::Footer, shell[3]);
 
     match &app.input_mode {
         InputMode::AddUrl => render_input(frame, app, "Paste GitHub repository URL"),
-        InputMode::ConfirmRemove { name } => {
-            render_confirm(frame, &format!("Remove '{name}' from nupackage.toml? y/N"))
-        }
+        InputMode::ConfirmRemove { name } => render_confirm(
+            frame,
+            &format!("Remove '{name}'? Enter confirms, Esc cancels"),
+        ),
         InputMode::Normal => {}
     }
 }
@@ -565,6 +594,7 @@ fn start_tui_action(
 
     let label = action.label();
     app.input_mode = InputMode::Normal;
+    app.set_log_visible(true);
     app.push_log(LogLine::Command(format!("qv {label}")));
     app.status = format!("Running {label}...");
     app.command_running = true;
@@ -661,24 +691,60 @@ fn focus_tab_at(app: &mut App, x: u16) {
     let Some(area) = region_rect(app, FocusRegion::Header) else {
         return;
     };
-    let inner_x = x.saturating_sub(area.x.saturating_add(1));
-    let inner_width = area.width.saturating_sub(2).max(1);
-    let tab_width = (inner_width / 3).max(1);
-    let tab = match (inner_x / tab_width).min(2) {
-        0 => Tab::Dependencies,
-        1 => Tab::Graph,
-        _ => Tab::Search,
-    };
-    set_tab(app, tab);
+    if let Some(tab) = header_tab_at(area, x) {
+        set_tab(app, tab);
+    }
+}
+
+fn header_tab_at(area: Rect, x: u16) -> Option<Tab> {
+    let inner = inner_block_area(area);
+    if inner.width == 0 || inner.height == 0 {
+        return None;
+    }
+
+    let mut current_x = inner.x;
+    for (index, (tab, title)) in HEADER_TABS.iter().enumerate() {
+        let tab_start = current_x;
+        current_x = current_x.saturating_add(text_width(HEADER_TAB_PADDING_LEFT));
+        current_x = current_x.saturating_add(text_width(title));
+        current_x = current_x.saturating_add(text_width(HEADER_TAB_PADDING_RIGHT));
+
+        if x >= tab_start && x < current_x {
+            return Some(*tab);
+        }
+
+        if index + 1 < HEADER_TABS.len() {
+            current_x = current_x.saturating_add(text_width(HEADER_TAB_DIVIDER));
+        }
+    }
+
+    None
 }
 
 fn set_tab(app: &mut App, tab: Tab) {
     app.tab = tab;
-    app.focus = match tab {
+    app.focus = default_focus_for_tab(tab);
+}
+
+fn default_focus_for_tab(tab: Tab) -> FocusRegion {
+    match tab {
         Tab::Dependencies => FocusRegion::DependencyList,
         Tab::Graph => FocusRegion::Graph,
         Tab::Search => FocusRegion::BuiltinPlugins,
-    };
+    }
+}
+
+fn inner_block_area(area: Rect) -> Rect {
+    Rect {
+        x: area.x.saturating_add(1),
+        y: area.y.saturating_add(1),
+        width: area.width.saturating_sub(2),
+        height: area.height.saturating_sub(2),
+    }
+}
+
+fn text_width(text: &str) -> u16 {
+    text.chars().count() as u16
 }
 
 fn select_dependency_at(app: &mut App, y: u16) {
@@ -706,9 +772,9 @@ fn select_builtin_plugin_at(app: &mut App, y: u16) {
 }
 
 fn render_header(frame: &mut ratatui::Frame<'_>, app: &App, area: Rect) {
-    let titles = ["Dependencies", "Graph", "Add"]
+    let titles = HEADER_TABS
         .iter()
-        .map(|title| Line::from(Span::styled(*title, Style::default().fg(Color::Cyan))))
+        .map(|(_, title)| Line::from(Span::styled(*title, Style::default().fg(Color::Cyan))))
         .collect::<Vec<_>>();
     let selected = match app.tab {
         Tab::Dependencies => 0,
@@ -723,6 +789,8 @@ fn render_header(frame: &mut ratatui::Frame<'_>, app: &App, area: Rect) {
     let tabs = Tabs::new(titles)
         .select(selected)
         .block(focused_block(app, FocusRegion::Header, title))
+        .divider(HEADER_TAB_DIVIDER)
+        .padding(HEADER_TAB_PADDING_LEFT, HEADER_TAB_PADDING_RIGHT)
         .highlight_style(
             Style::default()
                 .fg(Color::Yellow)
@@ -1122,13 +1190,22 @@ fn render_search(frame: &mut ratatui::Frame<'_>, app: &mut App, area: Rect) {
 }
 
 fn render_footer(frame: &mut ratatui::Frame<'_>, app: &App, area: Rect) {
+    let log_hint = if app.log_visible {
+        "/ hide log"
+    } else {
+        "/ show log"
+    };
     let keys = match app.tab {
         Tab::Dependencies => {
-            "q quit | tab switch | j/k select | PgUp/PgDn scroll | [/] log | i install | u update | r remove | a add"
+            format!(
+                "q quit | tab switch | j/k select | PgUp/PgDn scroll | {log_hint} | i install | u update | r remove | a add"
+            )
         }
-        Tab::Graph => "q quit | tab switch | d dependencies | a add URL | [/] log",
+        Tab::Graph => format!("q quit | tab switch | d dependencies | a add URL | {log_hint}"),
         Tab::Search => {
-            "q quit | tab switch | j/k select plugin | Enter add plugin | a paste URL | m add repo module | p add repo plugin | [/] log"
+            format!(
+                "q quit | tab switch | j/k select plugin | Enter add plugin | a paste URL | m add repo module | p add repo plugin | {log_hint}"
+            )
         }
     };
     let text = format!("{keys}\n{}", app.status);
@@ -1211,7 +1288,7 @@ fn log_line(line: &LogLine) -> Line<'static> {
 }
 
 fn render_input(frame: &mut ratatui::Frame<'_>, app: &App, title: &str) {
-    let area = centered_rect_max(68, 7, frame.area());
+    let area = centered_rect_max(68, 3, frame.area());
     frame.render_widget(Clear, area);
     frame.render_widget(
         Paragraph::new(app.input.as_str()).block(
@@ -1225,7 +1302,7 @@ fn render_input(frame: &mut ratatui::Frame<'_>, app: &App, title: &str) {
 }
 
 fn render_confirm(frame: &mut ratatui::Frame<'_>, message: &str) {
-    let area = centered_rect_max(56, 7, frame.area());
+    let area = centered_rect_max(56, 3, frame.area());
     frame.render_widget(Clear, area);
     frame.render_widget(
         Paragraph::new(message).alignment(Alignment::Center).block(
@@ -1282,6 +1359,7 @@ fn handle_normal_key(app: &mut App, code: KeyCode, modifiers: KeyModifiers) {
         }
         KeyCode::PageDown => scroll_focused(app, 10),
         KeyCode::PageUp => scroll_focused(app, -10),
+        KeyCode::Char('/') => app.toggle_log_visible(),
         KeyCode::Char(']') => {
             app.scroll_log_down(3);
         }
@@ -1375,8 +1453,13 @@ fn handle_url_key(app: &mut App, code: KeyCode) {
 
 fn handle_remove_confirm_key(app: &mut App, code: KeyCode, name: String) {
     match code {
-        KeyCode::Char('y') | KeyCode::Char('Y') => app.action = Some(TuiAction::Remove { name }),
-        _ => app.input_mode = InputMode::Normal,
+        KeyCode::Enter | KeyCode::Char('y') | KeyCode::Char('Y') => {
+            app.action = Some(TuiAction::Remove { name });
+        }
+        KeyCode::Esc | KeyCode::Char('n') | KeyCode::Char('N') => {
+            app.input_mode = InputMode::Normal;
+        }
+        _ => {}
     }
 }
 
@@ -1573,8 +1656,8 @@ fn previous_tab(tab: Tab) -> Tab {
 }
 
 fn centered_rect_max(max_width: u16, max_height: u16, area: Rect) -> Rect {
-    let width = max_width.min(area.width.saturating_sub(4)).max(20);
-    let height = max_height.min(area.height.saturating_sub(2)).max(5);
+    let width = max_width.min(area.width.saturating_sub(4).max(1));
+    let height = max_height.min(area.height.saturating_sub(2).max(1));
     Rect {
         x: area.x + area.width.saturating_sub(width) / 2,
         y: area.y + area.height.saturating_sub(height) / 2,
@@ -1586,6 +1669,39 @@ fn centered_rect_max(max_width: u16, max_height: u16, area: Rect) -> Rect {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_app() -> App {
+        App {
+            project_dir: Some(PathBuf::from("/project")),
+            package_name: "test".to_string(),
+            package_version: "0.1.0".to_string(),
+            rows: Vec::new(),
+            tab: Tab::Dependencies,
+            selected: 0,
+            search_selected: 0,
+            readme_scroll: 0,
+            detail_readme_scroll: 0,
+            graph_scroll: 0,
+            local_readme: String::new(),
+            local_license: String::new(),
+            status: String::new(),
+            input: String::new(),
+            readme_url: String::new(),
+            readme: String::new(),
+            input_mode: InputMode::Normal,
+            action: None,
+            logs: Vec::new(),
+            log_scroll: 0,
+            follow_log: true,
+            log_visible: false,
+            command_rx: None,
+            command_running: false,
+            pending_reload: false,
+            focus: FocusRegion::DependencyList,
+            regions: Vec::new(),
+            quit: false,
+        }
+    }
 
     #[test]
     fn parse_github_url() {
@@ -1662,5 +1778,54 @@ license = "Apache-2.0"
         assert_eq!(read_local_license(&temp_dir), "Apache-2.0");
 
         let _ = std::fs::remove_dir_all(&temp_dir);
+    }
+
+    #[test]
+    fn header_tab_at_matches_rendered_titles() {
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 40,
+            height: 3,
+        };
+
+        assert_eq!(header_tab_at(area, 1), Some(Tab::Dependencies));
+        assert_eq!(header_tab_at(area, 17), Some(Tab::Graph));
+        assert_eq!(header_tab_at(area, 25), Some(Tab::Search));
+        assert_eq!(header_tab_at(area, 15), None);
+    }
+
+    #[test]
+    fn start_tui_action_reveals_log() {
+        let mut app = test_app();
+
+        start_tui_action(&mut app, TuiAction::Install, Arc::new(|_, _| Ok(())));
+
+        assert!(app.log_visible);
+    }
+
+    #[test]
+    fn remove_confirm_enter_submits_action() {
+        let mut app = test_app();
+
+        handle_remove_confirm_key(&mut app, KeyCode::Enter, "demo".to_string());
+
+        assert_eq!(
+            app.action,
+            Some(TuiAction::Remove {
+                name: "demo".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn hiding_log_moves_focus_back_to_current_tab() {
+        let mut app = test_app();
+        app.focus = FocusRegion::CommandLog;
+        app.log_visible = true;
+
+        app.set_log_visible(false);
+
+        assert_eq!(app.focus, FocusRegion::DependencyList);
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -15,7 +15,10 @@ use crossterm::{
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
 use leaves::theme::TERMINAL;
-use leaves::{MarkdownTheme, parse_markdown_with_width};
+use leaves::{
+    MarkdownTheme, parse_markdown_with_width, syntax_set_with_bundled_syntaxes,
+    theme_set_with_bundled_themes,
+};
 use ratatui::{
     Terminal,
     backend::CrosstermBackend,
@@ -50,8 +53,18 @@ const HEADER_TAB_PADDING_LEFT: &str = " ";
 const HEADER_TAB_PADDING_RIGHT: &str = " ";
 const HEADER_TAB_DIVIDER: &str = "|";
 
-static MARKDOWN_SYNTAX_SET: LazyLock<SyntaxSet> = LazyLock::new(SyntaxSet::load_defaults_newlines);
-static MARKDOWN_THEME_SET: LazyLock<ThemeSet> = LazyLock::new(ThemeSet::load_defaults);
+static MARKDOWN_SYNTAX_SET: LazyLock<SyntaxSet> = LazyLock::new(|| {
+    syntax_set_with_bundled_syntaxes().unwrap_or_else(|err| {
+        eprintln!("warning: failed to load bundled markdown syntaxes: {err}");
+        SyntaxSet::load_defaults_newlines()
+    })
+});
+static MARKDOWN_THEME_SET: LazyLock<ThemeSet> = LazyLock::new(|| {
+    theme_set_with_bundled_themes().unwrap_or_else(|err| {
+        eprintln!("warning: failed to load bundled markdown themes: {err}");
+        ThemeSet::load_defaults()
+    })
+});
 static MARKDOWN_THEME: LazyLock<MarkdownTheme> = LazyLock::new(|| TERMINAL);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -739,7 +752,7 @@ fn markdown_lines(content: &str, width: u16) -> Vec<Line<'static>> {
     let render_width = usize::from(width.saturating_sub(2)).max(20);
     let syntect_theme = MARKDOWN_THEME_SET
         .themes
-        .get("base16-ocean.dark")
+        .get("ansi")
         .or_else(|| MARKDOWN_THEME_SET.themes.values().next())
         .expect("syntect default theme set should not be empty");
     let (lines, _) = parse_markdown_with_width(

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -58,9 +58,22 @@ static MARKDOWN_THEME: LazyLock<MarkdownTheme> = LazyLock::new(|| TERMINAL);
 pub enum TuiAction {
     Install,
     Update,
-    Remove { name: String },
-    AddModule { url: String },
-    AddPlugin { url: String },
+    Remove {
+        name: String,
+    },
+    AddModule {
+        url: String,
+        tag: Option<String>,
+        rev: Option<String>,
+        branch: Option<String>,
+    },
+    AddPlugin {
+        url: String,
+        tag: Option<String>,
+        rev: Option<String>,
+        branch: Option<String>,
+        bin: Option<String>,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -80,8 +93,46 @@ const HEADER_TABS: [(Tab, &str); 3] = [
 enum InputMode {
     Normal,
     AddUrl,
-    ConfirmRemove { name: String },
+    BuiltinPlugins,
+    ChooseRef {
+        target: AddTarget,
+    },
+    AddRefValue {
+        target: AddTarget,
+        ref_kind: RefInputKind,
+    },
+    ConfirmRemove {
+        name: String,
+    },
 }
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum AddTarget {
+    Module { url: String },
+    Plugin { url: String },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RefInputKind {
+    Tag,
+    Rev,
+    Branch,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RefChoice {
+    Auto,
+    Tag,
+    Branch,
+    Rev,
+}
+
+const REF_CHOICES: [RefChoice; 4] = [
+    RefChoice::Auto,
+    RefChoice::Tag,
+    RefChoice::Branch,
+    RefChoice::Rev,
+];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum DependencyKind {
@@ -135,6 +186,7 @@ struct App {
     tab: Tab,
     selected: usize,
     search_selected: usize,
+    ref_choice_selected: usize,
     readme_scroll: u16,
     detail_readme_scroll: u16,
     graph_scroll: u16,
@@ -237,6 +289,7 @@ impl App {
                 tab: Tab::Dependencies,
                 selected: 0,
                 search_selected: 0,
+                ref_choice_selected: 0,
                 readme_scroll: 0,
                 detail_readme_scroll: 0,
                 graph_scroll: 0,
@@ -286,6 +339,7 @@ impl App {
             tab: Tab::Dependencies,
             selected: 0,
             search_selected: 0,
+            ref_choice_selected: 0,
             readme_scroll: 0,
             detail_readme_scroll: 0,
             graph_scroll: 0,
@@ -502,6 +556,11 @@ fn render(frame: &mut ratatui::Frame<'_>, app: &mut App) {
 
     match &app.input_mode {
         InputMode::AddUrl => render_input(frame, app, "Paste GitHub repository URL"),
+        InputMode::BuiltinPlugins => render_builtin_plugins_dialog(frame, app),
+        InputMode::ChooseRef { target } => render_ref_choice(frame, app, target),
+        InputMode::AddRefValue { ref_kind, .. } => {
+            render_input(frame, app, ref_input_title(*ref_kind))
+        }
         InputMode::ConfirmRemove { name } => render_confirm(
             frame,
             &format!("Remove '{name}'? Enter confirms, Esc cancels"),
@@ -635,9 +694,32 @@ impl TuiAction {
             TuiAction::Install => "install".to_string(),
             TuiAction::Update => "update".to_string(),
             TuiAction::Remove { name } => format!("remove {name}"),
-            TuiAction::AddModule { url } => format!("add {url}"),
-            TuiAction::AddPlugin { url } => format!("add-plugin {url}"),
+            TuiAction::AddModule {
+                url,
+                tag,
+                rev,
+                branch,
+            } => format!("add {}{}", url, ref_label(tag, rev, branch)),
+            TuiAction::AddPlugin {
+                url,
+                tag,
+                rev,
+                branch,
+                ..
+            } => format!("add-plugin {}{}", url, ref_label(tag, rev, branch)),
         }
+    }
+}
+
+fn ref_label(tag: &Option<String>, rev: &Option<String>, branch: &Option<String>) -> String {
+    if let Some(tag) = tag {
+        format!(" --tag {tag}")
+    } else if let Some(rev) = rev {
+        format!(" --rev {}", short_rev(rev))
+    } else if let Some(branch) = branch {
+        format!(" --branch {branch}")
+    } else {
+        String::new()
     }
 }
 
@@ -764,7 +846,7 @@ fn default_focus_for_tab(tab: Tab) -> FocusRegion {
     match tab {
         Tab::Dependencies => FocusRegion::DependencyList,
         Tab::Graph => FocusRegion::Graph,
-        Tab::Search => FocusRegion::BuiltinPlugins,
+        Tab::Search => FocusRegion::SearchReadme,
     }
 }
 
@@ -1161,18 +1243,12 @@ fn render_graph(frame: &mut ratatui::Frame<'_>, app: &App, area: Rect) {
 }
 
 fn render_search(frame: &mut ratatui::Frame<'_>, app: &mut App, area: Rect) {
-    let horizontal_chunks = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
-        .split(area);
-    app.register_region(FocusRegion::BuiltinPlugins, horizontal_chunks[1]);
-
-    let left_chunks = Layout::default()
+    let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Length(3), Constraint::Min(5)])
-        .split(horizontal_chunks[0]);
-    app.register_region(FocusRegion::SearchUrl, left_chunks[0]);
-    app.register_region(FocusRegion::SearchReadme, left_chunks[1]);
+        .split(area);
+    app.register_region(FocusRegion::SearchUrl, chunks[0]);
+    app.register_region(FocusRegion::SearchReadme, chunks[1]);
 
     let url = if app.readme_url.is_empty() {
         "No repository loaded".to_string()
@@ -1185,44 +1261,24 @@ fn render_search(frame: &mut ratatui::Frame<'_>, app: &mut App, area: Rect) {
             FocusRegion::SearchUrl,
             "GitHub Repository",
         )),
-        left_chunks[0],
+        chunks[0],
     );
 
-    let readme_lines = markdown_lines(app.readme.as_str(), left_chunks[1].width);
+    let readme_lines = markdown_lines(app.readme.as_str(), chunks[1].width);
     let content_height = readme_lines.len().saturating_sub(1) as u16;
     let paragraph = Paragraph::new(readme_lines)
         .block(focused_block(app, FocusRegion::SearchReadme, "README"))
         .scroll((app.readme_scroll, 0))
         .wrap(Wrap { trim: false });
-    frame.render_widget(paragraph, left_chunks[1]);
+    frame.render_widget(paragraph, chunks[1]);
 
     let mut scrollbar_state =
         ScrollbarState::new(content_height as usize).position(app.readme_scroll as usize);
     frame.render_stateful_widget(
         Scrollbar::new(ScrollbarOrientation::VerticalRight),
-        left_chunks[1],
+        chunks[1],
         &mut scrollbar_state,
     );
-
-    let items: Vec<ListItem> = BUILTIN_PLUGINS
-        .iter()
-        .map(|p| ListItem::new(Line::from(p.to_string())))
-        .collect();
-    let list = List::new(items)
-        .block(focused_block(
-            app,
-            FocusRegion::BuiltinPlugins,
-            "Built-in Plugins",
-        ))
-        .highlight_symbol("> ")
-        .highlight_style(
-            Style::default()
-                .fg(Color::Yellow)
-                .add_modifier(Modifier::BOLD),
-        );
-    let mut list_state = ListState::default();
-    list_state.select(Some(app.search_selected));
-    frame.render_stateful_widget(list, horizontal_chunks[1], &mut list_state);
 }
 
 fn render_footer(frame: &mut ratatui::Frame<'_>, app: &App, area: Rect) {
@@ -1240,7 +1296,7 @@ fn render_footer(frame: &mut ratatui::Frame<'_>, app: &App, area: Rect) {
         Tab::Graph => format!("q quit | tab switch | d dependencies | a add URL | {log_hint}"),
         Tab::Search => {
             format!(
-                "q quit | tab switch | j/k select plugin | Enter add plugin | a paste URL | m add repo module | p add repo plugin | {log_hint}"
+                "q quit | tab switch | a paste URL | b built-ins | m add repo module | p add repo plugin | {log_hint}"
             )
         }
     };
@@ -1351,10 +1407,86 @@ fn render_confirm(frame: &mut ratatui::Frame<'_>, message: &str) {
     );
 }
 
+fn render_builtin_plugins_dialog(frame: &mut ratatui::Frame<'_>, app: &App) {
+    let area = centered_rect_max(44, 12, frame.area());
+    frame.render_widget(Clear, area);
+    let items: Vec<ListItem> = BUILTIN_PLUGINS
+        .iter()
+        .map(|p| ListItem::new(Line::from(p.to_string())))
+        .collect();
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .title("Built-in Plugins - Enter adds, Esc cancels")
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(focus_color())),
+        )
+        .highlight_symbol("> ")
+        .highlight_style(
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        );
+    let mut list_state = ListState::default();
+    list_state.select(Some(app.search_selected));
+    frame.render_stateful_widget(list, area, &mut list_state);
+}
+
+fn render_ref_choice(frame: &mut ratatui::Frame<'_>, app: &App, target: &AddTarget) {
+    let title = match target {
+        AddTarget::Module { .. } => "Add Module Ref",
+        AddTarget::Plugin { .. } => "Add Plugin Ref",
+    };
+    let area = centered_rect_max(62, 8, frame.area());
+    frame.render_widget(Clear, area);
+    let items: Vec<ListItem> = REF_CHOICES
+        .iter()
+        .map(|choice| ListItem::new(Line::from(ref_choice_label(*choice))))
+        .collect();
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .title(title)
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(focus_color())),
+        )
+        .highlight_symbol("> ")
+        .highlight_style(
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        );
+    let mut list_state = ListState::default();
+    list_state.select(Some(app.ref_choice_selected));
+    frame.render_stateful_widget(list, area, &mut list_state);
+}
+
+fn ref_input_title(ref_kind: RefInputKind) -> &'static str {
+    match ref_kind {
+        RefInputKind::Tag => "Version tag",
+        RefInputKind::Rev => "Revision",
+        RefInputKind::Branch => "Branch",
+    }
+}
+
+fn ref_choice_label(choice: RefChoice) -> &'static str {
+    match choice {
+        RefChoice::Auto => "auto-detect latest tag/default branch (a)",
+        RefChoice::Tag => "version tag (v)",
+        RefChoice::Branch => "branch (b)",
+        RefChoice::Rev => "revision (r)",
+    }
+}
+
 fn handle_key(app: &mut App, code: KeyCode, modifiers: KeyModifiers) {
     match app.input_mode.clone() {
         InputMode::Normal => handle_normal_key(app, code, modifiers),
         InputMode::AddUrl => handle_url_key(app, code),
+        InputMode::BuiltinPlugins => handle_builtin_plugins_key(app, code),
+        InputMode::ChooseRef { target } => handle_ref_choice_key(app, code, target),
+        InputMode::AddRefValue { target, ref_kind } => {
+            handle_ref_value_key(app, code, target, ref_kind)
+        }
         InputMode::ConfirmRemove { name } => handle_remove_confirm_key(app, code, name),
     }
 }
@@ -1423,6 +1555,10 @@ fn handle_normal_key(app: &mut App, code: KeyCode, modifiers: KeyModifiers) {
             app.input.clear();
             app.input_mode = InputMode::AddUrl;
         }
+        KeyCode::Char('b') if app.can_manage() && app.tab == Tab::Search => {
+            app.input_mode = InputMode::BuiltinPlugins;
+            app.status = "Choose a built-in plugin.".to_string();
+        }
         KeyCode::Char('r') if app.can_manage() => {
             if let Some(row) = app.selected_row()
                 && !matches!(row.kind, DependencyKind::Transitive)
@@ -1433,23 +1569,141 @@ fn handle_normal_key(app: &mut App, code: KeyCode, modifiers: KeyModifiers) {
             }
         }
         KeyCode::Char('m') if app.can_manage() && !app.readme_url.is_empty() => {
-            app.action = Some(TuiAction::AddModule {
-                url: app.readme_url.clone(),
-            });
+            app.ref_choice_selected = 0;
+            app.input_mode = InputMode::ChooseRef {
+                target: AddTarget::Module {
+                    url: app.readme_url.clone(),
+                },
+            };
+            app.status = "Choose how to pin the module.".to_string();
         }
         KeyCode::Char('p') if app.can_manage() && !app.readme_url.is_empty() => {
-            app.action = Some(TuiAction::AddPlugin {
-                url: app.readme_url.clone(),
-            });
-        }
-        KeyCode::Enter => {
-            if app.tab == Tab::Search && app.can_manage() {
-                app.action = Some(TuiAction::AddPlugin {
-                    url: BUILTIN_PLUGINS[app.search_selected].to_string(),
-                });
-            }
+            app.ref_choice_selected = 0;
+            app.input_mode = InputMode::ChooseRef {
+                target: AddTarget::Plugin {
+                    url: app.readme_url.clone(),
+                },
+            };
+            app.status = "Choose how to pin the plugin.".to_string();
         }
         _ => {}
+    }
+}
+
+fn handle_builtin_plugins_key(app: &mut App, code: KeyCode) {
+    match code {
+        KeyCode::Esc => app.input_mode = InputMode::Normal,
+        KeyCode::Down | KeyCode::Char('j') => {
+            if app.search_selected + 1 < BUILTIN_PLUGINS.len() {
+                app.search_selected += 1;
+            }
+        }
+        KeyCode::Up | KeyCode::Char('k') => {
+            if app.search_selected > 0 {
+                app.search_selected -= 1;
+            }
+        }
+        KeyCode::Enter => {
+            app.action = Some(TuiAction::AddPlugin {
+                url: BUILTIN_PLUGINS[app.search_selected].to_string(),
+                tag: None,
+                rev: None,
+                branch: None,
+                bin: None,
+            });
+            app.input_mode = InputMode::Normal;
+        }
+        _ => {}
+    }
+}
+
+fn handle_ref_choice_key(app: &mut App, code: KeyCode, target: AddTarget) {
+    match code {
+        KeyCode::Esc => app.input_mode = InputMode::Normal,
+        KeyCode::Down | KeyCode::Char('j') => {
+            if app.ref_choice_selected + 1 < REF_CHOICES.len() {
+                app.ref_choice_selected += 1;
+            }
+        }
+        KeyCode::Up | KeyCode::Char('k') => {
+            if app.ref_choice_selected > 0 {
+                app.ref_choice_selected -= 1;
+            }
+        }
+        KeyCode::Enter => submit_ref_choice(app, target, REF_CHOICES[app.ref_choice_selected]),
+        KeyCode::Char('a') => submit_ref_choice(app, target, RefChoice::Auto),
+        KeyCode::Char('v') | KeyCode::Char('t') => submit_ref_choice(app, target, RefChoice::Tag),
+        KeyCode::Char('r') => submit_ref_choice(app, target, RefChoice::Rev),
+        KeyCode::Char('b') => submit_ref_choice(app, target, RefChoice::Branch),
+        _ => {}
+    }
+}
+
+fn submit_ref_choice(app: &mut App, target: AddTarget, choice: RefChoice) {
+    match choice {
+        RefChoice::Auto => {
+            app.action = Some(action_for_target(target, None, None, None));
+            app.input_mode = InputMode::Normal;
+        }
+        RefChoice::Tag => start_ref_value_input(app, target, RefInputKind::Tag),
+        RefChoice::Rev => start_ref_value_input(app, target, RefInputKind::Rev),
+        RefChoice::Branch => start_ref_value_input(app, target, RefInputKind::Branch),
+    }
+}
+
+fn start_ref_value_input(app: &mut App, target: AddTarget, ref_kind: RefInputKind) {
+    app.input.clear();
+    app.input_mode = InputMode::AddRefValue { target, ref_kind };
+}
+
+fn handle_ref_value_key(app: &mut App, code: KeyCode, target: AddTarget, ref_kind: RefInputKind) {
+    match code {
+        KeyCode::Enter => {
+            let value = app.input.trim().to_string();
+            if value.is_empty() {
+                app.status = format!(
+                    "Enter a {} first.",
+                    ref_input_title(ref_kind).to_lowercase()
+                );
+                return;
+            }
+            let (tag, rev, branch) = match ref_kind {
+                RefInputKind::Tag => (Some(value), None, None),
+                RefInputKind::Rev => (None, Some(value), None),
+                RefInputKind::Branch => (None, None, Some(value)),
+            };
+            app.action = Some(action_for_target(target, tag, rev, branch));
+            app.input_mode = InputMode::Normal;
+        }
+        KeyCode::Esc => app.input_mode = InputMode::Normal,
+        KeyCode::Backspace => {
+            app.input.pop();
+        }
+        KeyCode::Char(c) => app.input.push(c),
+        _ => {}
+    }
+}
+
+fn action_for_target(
+    target: AddTarget,
+    tag: Option<String>,
+    rev: Option<String>,
+    branch: Option<String>,
+) -> TuiAction {
+    match target {
+        AddTarget::Module { url } => TuiAction::AddModule {
+            url,
+            tag,
+            rev,
+            branch,
+        },
+        AddTarget::Plugin { url } => TuiAction::AddPlugin {
+            url,
+            tag,
+            rev,
+            branch,
+            bin: None,
+        },
     }
 }
 
@@ -1715,6 +1969,7 @@ mod tests {
             tab: Tab::Dependencies,
             selected: 0,
             search_selected: 0,
+            ref_choice_selected: 0,
             readme_scroll: 0,
             detail_readme_scroll: 0,
             graph_scroll: 0,
@@ -1916,5 +2171,107 @@ license = "Apache-2.0"
         app.set_log_visible(false);
 
         assert_eq!(app.focus, FocusRegion::DependencyList);
+    }
+
+    #[test]
+    fn add_tab_b_opens_builtin_plugin_dialog() {
+        let mut app = test_app();
+        app.tab = Tab::Search;
+
+        handle_normal_key(&mut app, KeyCode::Char('b'), KeyModifiers::NONE);
+
+        assert_eq!(app.input_mode, InputMode::BuiltinPlugins);
+    }
+
+    #[test]
+    fn builtin_plugin_dialog_enter_adds_selected_core_plugin() {
+        let mut app = test_app();
+        app.search_selected = 2;
+        app.input_mode = InputMode::BuiltinPlugins;
+
+        handle_builtin_plugins_key(&mut app, KeyCode::Enter);
+
+        assert_eq!(
+            app.action,
+            Some(TuiAction::AddPlugin {
+                url: BUILTIN_PLUGINS[2].to_string(),
+                tag: None,
+                rev: None,
+                branch: None,
+                bin: None,
+            })
+        );
+    }
+
+    #[test]
+    fn repo_add_can_choose_branch_before_submitting() {
+        let mut app = test_app();
+        app.readme_url = "https://github.com/nushell/nu_scripts".to_string();
+
+        handle_normal_key(&mut app, KeyCode::Char('m'), KeyModifiers::NONE);
+        assert_eq!(
+            app.input_mode,
+            InputMode::ChooseRef {
+                target: AddTarget::Module {
+                    url: "https://github.com/nushell/nu_scripts".to_string()
+                }
+            }
+        );
+
+        handle_ref_choice_key(
+            &mut app,
+            KeyCode::Char('b'),
+            AddTarget::Module {
+                url: "https://github.com/nushell/nu_scripts".to_string(),
+            },
+        );
+        app.input = "main".to_string();
+        handle_ref_value_key(
+            &mut app,
+            KeyCode::Enter,
+            AddTarget::Module {
+                url: "https://github.com/nushell/nu_scripts".to_string(),
+            },
+            RefInputKind::Branch,
+        );
+
+        assert_eq!(
+            app.action,
+            Some(TuiAction::AddModule {
+                url: "https://github.com/nushell/nu_scripts".to_string(),
+                tag: None,
+                rev: None,
+                branch: Some("main".to_string()),
+            })
+        );
+    }
+
+    #[test]
+    fn ref_choice_dialog_supports_jk_navigation_and_enter() {
+        let mut app = test_app();
+        let target = AddTarget::Plugin {
+            url: "https://github.com/nushell/nu_plugin_inc".to_string(),
+        };
+
+        handle_ref_choice_key(&mut app, KeyCode::Char('j'), target.clone());
+        handle_ref_choice_key(&mut app, KeyCode::Char('j'), target.clone());
+
+        assert_eq!(app.ref_choice_selected, 2);
+
+        handle_ref_choice_key(&mut app, KeyCode::Char('k'), target.clone());
+
+        assert_eq!(app.ref_choice_selected, 1);
+
+        handle_ref_choice_key(&mut app, KeyCode::Enter, target);
+
+        assert_eq!(
+            app.input_mode,
+            InputMode::AddRefValue {
+                target: AddTarget::Plugin {
+                    url: "https://github.com/nushell/nu_plugin_inc".to_string(),
+                },
+                ref_kind: RefInputKind::Tag,
+            }
+        );
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -23,7 +23,7 @@ use ratatui::{
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{
-        Block, Borders, Clear, List, ListItem, ListState, Paragraph, Scrollbar,
+        Block, BorderType, Borders, Clear, List, ListItem, ListState, Paragraph, Scrollbar,
         ScrollbarOrientation, ScrollbarState, Tabs, Wrap,
     },
 };
@@ -724,7 +724,10 @@ fn ref_label(tag: &Option<String>, rev: &Option<String>, branch: &Option<String>
 }
 
 fn focused_block<'a>(app: &App, region: FocusRegion, title: impl Into<Line<'a>>) -> Block<'a> {
-    let block = Block::default().borders(Borders::ALL).title(title);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .title(title);
     if app.focus == region {
         block.border_style(Style::default().fg(focus_color()))
     } else {
@@ -1387,6 +1390,7 @@ fn render_input(frame: &mut ratatui::Frame<'_>, app: &App, title: &str) {
             Block::default()
                 .title(title)
                 .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
                 .border_style(Style::default().fg(focus_color())),
         ),
         area,
@@ -1401,6 +1405,7 @@ fn render_confirm(frame: &mut ratatui::Frame<'_>, message: &str) {
             Block::default()
                 .title("Confirm")
                 .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
                 .border_style(Style::default().fg(focus_color())),
         ),
         area,
@@ -1419,6 +1424,7 @@ fn render_builtin_plugins_dialog(frame: &mut ratatui::Frame<'_>, app: &App) {
             Block::default()
                 .title("Built-in Plugins - Enter adds, Esc cancels")
                 .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
                 .border_style(Style::default().fg(focus_color())),
         )
         .highlight_symbol("> ")
@@ -1448,6 +1454,7 @@ fn render_ref_choice(frame: &mut ratatui::Frame<'_>, app: &App, target: &AddTarg
             Block::default()
                 .title(title)
                 .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
                 .border_style(Style::default().fg(focus_color())),
         )
         .highlight_symbol("> ")

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::io::{self, IsTerminal};
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::{Arc, mpsc};
+use std::sync::{Arc, LazyLock, mpsc};
 use std::thread;
 use std::time::Duration;
 
@@ -14,6 +14,8 @@ use crossterm::{
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
+use leaves::theme::TERMINAL;
+use leaves::{MarkdownTheme, parse_markdown_with_width};
 use ratatui::{
     Terminal,
     backend::CrosstermBackend,
@@ -25,6 +27,7 @@ use ratatui::{
         ScrollbarOrientation, ScrollbarState, Tabs, Wrap,
     },
 };
+use syntect::{highlighting::ThemeSet, parsing::SyntaxSet};
 
 use crate::error::{QuiverError, Result};
 use crate::lockfile::{LockedPackageKind, Lockfile};
@@ -46,6 +49,10 @@ const LOG_PANEL_HEIGHT: u16 = 8;
 const HEADER_TAB_PADDING_LEFT: &str = " ";
 const HEADER_TAB_PADDING_RIGHT: &str = " ";
 const HEADER_TAB_DIVIDER: &str = "|";
+
+static MARKDOWN_SYNTAX_SET: LazyLock<SyntaxSet> = LazyLock::new(SyntaxSet::load_defaults_newlines);
+static MARKDOWN_THEME_SET: LazyLock<ThemeSet> = LazyLock::new(ThemeSet::load_defaults);
+static MARKDOWN_THEME: LazyLock<MarkdownTheme> = LazyLock::new(|| TERMINAL);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TuiAction {
@@ -643,6 +650,23 @@ fn focused_block<'a>(app: &App, region: FocusRegion, title: impl Into<Line<'a>>)
     }
 }
 
+fn markdown_lines(content: &str, width: u16) -> Vec<Line<'static>> {
+    let render_width = usize::from(width.saturating_sub(2)).max(20);
+    let syntect_theme = MARKDOWN_THEME_SET
+        .themes
+        .get("base16-ocean.dark")
+        .or_else(|| MARKDOWN_THEME_SET.themes.values().next())
+        .expect("syntect default theme set should not be empty");
+    let (lines, _) = parse_markdown_with_width(
+        content,
+        &MARKDOWN_SYNTAX_SET,
+        syntect_theme,
+        render_width,
+        &MARKDOWN_THEME,
+    );
+    lines
+}
+
 fn focus_color() -> Color {
     Color::Green
 }
@@ -884,13 +908,14 @@ fn render_dependencies(frame: &mut ratatui::Frame<'_>, app: &mut App, area: Rect
         app.local_readme.as_str()
     };
 
-    let readme_paragraph = Paragraph::new(tui_markdown::from_str(readme_content))
+    let readme_lines = markdown_lines(readme_content, right_chunks[1].width);
+    let content_height = readme_lines.len().saturating_sub(1) as u16;
+    let readme_paragraph = Paragraph::new(readme_lines)
         .block(focused_block(app, FocusRegion::DependencyReadme, "README"))
         .scroll((app.detail_readme_scroll, 0))
         .wrap(Wrap { trim: false });
     frame.render_widget(readme_paragraph, right_chunks[1]);
 
-    let content_height = app.local_readme.lines().count().saturating_sub(1) as u16;
     let mut scrollbar_state =
         ScrollbarState::new(content_height as usize).position(app.detail_readme_scroll as usize);
     frame.render_stateful_widget(
@@ -1163,13 +1188,14 @@ fn render_search(frame: &mut ratatui::Frame<'_>, app: &mut App, area: Rect) {
         left_chunks[0],
     );
 
-    let paragraph = Paragraph::new(tui_markdown::from_str(app.readme.as_str()))
+    let readme_lines = markdown_lines(app.readme.as_str(), left_chunks[1].width);
+    let content_height = readme_lines.len().saturating_sub(1) as u16;
+    let paragraph = Paragraph::new(readme_lines)
         .block(focused_block(app, FocusRegion::SearchReadme, "README"))
         .scroll((app.readme_scroll, 0))
         .wrap(Wrap { trim: false });
     frame.render_widget(paragraph, left_chunks[1]);
 
-    let content_height = app.readme.lines().count().saturating_sub(1) as u16;
     let mut scrollbar_state =
         ScrollbarState::new(content_height as usize).position(app.readme_scroll as usize);
     frame.render_stateful_widget(

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -556,19 +556,29 @@ fn drain_command_events(app: &mut App) -> Result<()> {
 
 fn handle_mouse(app: &mut App, mouse: MouseEvent) {
     if let Some(region) = region_at(app, mouse.column, mouse.row) {
-        app.focus = region;
         match (mouse.kind, region) {
             (MouseEventKind::Down(MouseButton::Left), FocusRegion::Header) => {
                 focus_tab_at(app, mouse.column);
             }
             (MouseEventKind::Down(MouseButton::Left), FocusRegion::DependencyList) => {
+                app.focus = region;
                 select_dependency_at(app, mouse.row);
             }
             (MouseEventKind::Down(MouseButton::Left), FocusRegion::BuiltinPlugins) => {
+                app.focus = region;
                 select_builtin_plugin_at(app, mouse.row);
             }
-            (MouseEventKind::ScrollDown, _) => scroll_focused(app, 3),
-            (MouseEventKind::ScrollUp, _) => scroll_focused(app, -3),
+            (MouseEventKind::Down(MouseButton::Left), _) => {
+                app.focus = region;
+            }
+            (MouseEventKind::ScrollDown, _) => {
+                app.focus = region;
+                scroll_focused(app, 3);
+            }
+            (MouseEventKind::ScrollUp, _) => {
+                app.focus = region;
+                scroll_focused(app, -3);
+            }
             _ => {}
         }
     } else {
@@ -1793,6 +1803,59 @@ license = "Apache-2.0"
         assert_eq!(header_tab_at(area, 17), Some(Tab::Graph));
         assert_eq!(header_tab_at(area, 25), Some(Tab::Search));
         assert_eq!(header_tab_at(area, 15), None);
+    }
+
+    #[test]
+    fn tab_mouse_release_does_not_focus_header() {
+        let mut app = test_app();
+        app.regions.push((
+            FocusRegion::Header,
+            Rect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 3,
+            },
+        ));
+
+        handle_mouse(
+            &mut app,
+            MouseEvent {
+                kind: MouseEventKind::Up(MouseButton::Left),
+                column: 17,
+                row: 1,
+                modifiers: KeyModifiers::NONE,
+            },
+        );
+
+        assert_eq!(app.focus, FocusRegion::DependencyList);
+    }
+
+    #[test]
+    fn tab_mouse_down_switches_tab_without_focusing_header() {
+        let mut app = test_app();
+        app.regions.push((
+            FocusRegion::Header,
+            Rect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 3,
+            },
+        ));
+
+        handle_mouse(
+            &mut app,
+            MouseEvent {
+                kind: MouseEventKind::Down(MouseButton::Left),
+                column: 17,
+                row: 1,
+                modifiers: KeyModifiers::NONE,
+            },
+        );
+
+        assert_eq!(app.tab, Tab::Graph);
+        assert_eq!(app.focus, FocusRegion::Graph);
     }
 
     #[test]


### PR DESCRIPTION
## Added

- You can now run commands from within the TUI and the results will be shown in the log at the bottom (previously running a command like adding a dependency would close the TUI). The command log is hidden by default, can be toggled with `/`, and is shown automatically while TUI-triggered commands run. Closes #22.
- The TUI Add flow now lets repository modules and plugins choose how to pin the dependency before adding it: auto-detect, tag, branch, or revision.
- The TUI now supports clickable header tabs for switching between Dependencies, Graph, and Add.

## Changed

- TUI README rendering now uses `leaves` for true Markdown rendering and syntax highlighting for code blocks.
- TUI panes and dialogs now use rounded borders, and dependency detail labels are styled for easier scanning.
- The TUI Add page now gives the repository README preview the main pane instead of splitting it with the built-in plugin list.
- The TUI Add tab now opens built-in plugin selection in a focused dialog via `b`.
- TUI remove confirmation now accepts `Enter` to confirm and `Esc` to cancel.
- TUI mouse movement and button release no longer steal focus; focus changes on click or scroll instead.
