### PR TITLE
Switch Manifest and Config File Format to `nuon`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Unreleased
 
+## Changed
+
+- **BREAKING**: The package manifest is now `nupackage.nuon` instead of `nupackage.toml`. The lockfile is also in `nuon` format. Existing projects must migrate:
+  ```nushell
+  open nupackage.toml | to nuon --indent 2 | save -f nupackage.nuon
+  rm nupackage.toml
+  rm quiver.lock
+  qv install
+  ```
+- **BREAKING**: The global Quiver config is now `config.nuon`. Navigate to your global quiver config dir and run the following to migrate:
+  ```nushell
+    open config.toml | to nuon --indent 2 | save -f config.nuon
+    rm config.toml
+    rm quiver.lock
+    qv install -g
+  ```
+- Quiver will warn users with migration instructions when a legacy `nupackage.toml` or `config.toml` is detected.
+
 # Version 0.6.1 (2026-05-08)
 
 ## Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,6 +83,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,6 +108,39 @@ checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -104,10 +158,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "buf-trait"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21eaafc770e8c073d6c3facafe7617e774305d4954aa6351b9c452eb37ee17b4"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "bytesize"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
+
+[[package]]
+name = "byteyarn"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93e51d26468a15ea59f8525e0c13dc405db43e644a0b1e6d44346c72cf4cf7b"
+dependencies = [
+ "buf-trait",
+]
 
 [[package]]
 name = "cassowary"
@@ -137,10 +227,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "pure-rust-locales",
+ "serde",
+ "windows-link",
+]
+
+[[package]]
+name = "chrono-humanize"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799627e6b4d27827a814e837b9d8a504832086081806d45b1afa34dc982b023b"
+dependencies = [
+ "chrono",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
 
 [[package]]
 name = "clap"
@@ -162,6 +300,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -223,6 +362,12 @@ checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -430,6 +575,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +593,17 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -468,6 +635,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8137a6d5a2c50d6b0ebfcb9aaa91a28154e0a70605f112d30cb0cd4a78670477"
+dependencies = [
+ "fluent-bundle",
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-bundle"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01203cb8918f5711e73891b347816d932046f95f54207710bda99beaeb423bf4"
+dependencies = [
+ "fluent-langneg",
+ "fluent-syntax",
+ "intl-memoizer",
+ "intl_pluralrules",
+ "rustc-hash",
+ "self_cell",
+ "smallvec",
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-langneg"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eebbe59450baee8282d71676f3bfed5689aeab00b27545e83e5f14b1195e8b0"
+dependencies = [
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-syntax"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54f0d287c53ffd184d04d8677f590f4ac5379785529e5e08b1c8083acdd5c198"
+dependencies = [
+ "memchr",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,6 +690,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -546,6 +764,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,7 +777,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -561,6 +785,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -573,6 +802,30 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "icu_collections"
@@ -728,6 +981,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "intl-memoizer"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "310da2e345f5eb861e7a07ee182262e94975051db9e4223e909ba90f392f163f"
+dependencies = [
+ "type-map",
+ "unic-langid",
+]
+
+[[package]]
+name = "intl_pluralrules"
+version = "7.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078ea7b7c29a2b4df841a7f6ac8775ff6074020c6776d48491ce2268e068f972"
+dependencies = [
+ "unic-langid",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,6 +1025,15 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -775,6 +1071,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lean_string"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a262b6ae1dd9c2d3cf7977a816578b03bf8fb60b61545c395880f95eefc5b24"
+dependencies = [
+ "castaway",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
 name = "leaves"
 version = "0.1.1"
 source = "git+https://github.com/freepicheep/leaves.git?branch=main#79c8a9803c8a91c7c0b0c99665eb195c926c0b54"
@@ -789,9 +1097,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libgit2-sys"
@@ -805,6 +1113,27 @@ dependencies = [
  "libz-sys",
  "openssl-sys",
  "pkg-config",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
+name = "libproc"
+version = "0.14.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a54ad7278b8bc5301d5ffd2a94251c004feb971feba96c971ea4063645990757"
+dependencies = [
+ "bindgen",
+ "errno",
+ "libc",
 ]
 
 [[package]]
@@ -900,6 +1229,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "lscolors"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d60e266dfb1426eb2d24792602e041131fdc0236bb7007abc0e589acafd60929"
+dependencies = [
+ "aho-corasick",
+ "nu-ansi-term",
+]
+
+[[package]]
 name = "lzma-sys"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,6 +1257,12 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
+
+[[package]]
+name = "mach2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
 
 [[package]]
 name = "matchers"
@@ -924,6 +1278,40 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "owo-colors",
+ "supports-color",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "terminal_size",
+ "textwrap",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -959,10 +1347,41 @@ dependencies = [
  "pest_derive",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "tracing-subscriber",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -975,10 +1394,223 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-derive-value"
+version = "0.112.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e956c3fc512be60e3d31aa8f58d063bd0b11e06b89da53326b5e12c8f5f94b1b"
+dependencies = [
+ "heck",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "nu-engine"
+version = "0.112.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eae3d2f0c563e58a4ed1cbb8eab360f904d8ef737e9accfcf524795b0a6e9c5"
+dependencies = [
+ "fancy-regex",
+ "log",
+ "nu-experimental",
+ "nu-glob",
+ "nu-path",
+ "nu-protocol",
+ "nu-utils",
+]
+
+[[package]]
+name = "nu-experimental"
+version = "0.112.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f9952ce521ddc530a5bca70c62cbb8a6503a073f78b8aa6e96ea40adbe302e9"
+dependencies = [
+ "itertools 0.14.0",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "nu-glob"
+version = "0.112.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f454999da57e72aad847db6caed952b1fba6f51e21b388a13da80ff2452ed0"
+
+[[package]]
+name = "nu-parser"
+version = "0.112.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "103267abd1a39418360ba067587877eceaab78960288da5b528f78b026469f21"
+dependencies = [
+ "bytesize",
+ "chrono",
+ "itertools 0.14.0",
+ "log",
+ "nu-engine",
+ "nu-experimental",
+ "nu-path",
+ "nu-protocol",
+ "nu-utils",
+ "serde_json",
+]
+
+[[package]]
+name = "nu-path"
+version = "0.112.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6841982bbdf96ebc613d23957544f8d5c9a5b7a05627e4485f4558a0ab3ff04"
+dependencies = [
+ "dirs",
+ "omnipath",
+ "pwd",
+ "ref-cast",
+]
+
+[[package]]
+name = "nu-protocol"
+version = "0.112.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75081fd2e1d88b9f596a4ab5342097bba336e0dea9c9ad791746d62be24282e3"
+dependencies = [
+ "bytes",
+ "chrono",
+ "chrono-humanize",
+ "dirs",
+ "dirs-sys",
+ "fancy-regex",
+ "heck",
+ "indexmap",
+ "log",
+ "lru 0.16.4",
+ "memchr",
+ "miette",
+ "nix",
+ "nu-derive-value",
+ "nu-experimental",
+ "nu-glob",
+ "nu-path",
+ "nu-system",
+ "nu-utils",
+ "num-format",
+ "serde",
+ "serde_json",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
+ "thiserror 2.0.18",
+ "typetag",
+ "web-time",
+ "windows",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nu-system"
+version = "0.112.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbd7a734c96c69197496b502307eca408fa171898ba5d7228acdbbd02961d078"
+dependencies = [
+ "chrono",
+ "itertools 0.14.0",
+ "libc",
+ "libproc",
+ "log",
+ "mach2",
+ "nix",
+ "ntapi",
+ "nu-utils",
+ "procfs",
+ "sysinfo",
+ "uucore",
+ "web-time",
+ "windows",
+]
+
+[[package]]
+name = "nu-utils"
+version = "0.112.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46dbde833d407a88a82d170597ed73626d9a8e198f51ee16886343c0c3479e81"
+dependencies = [
+ "byteyarn",
+ "crossterm_winapi",
+ "fancy-regex",
+ "lean_string",
+ "log",
+ "lscolors",
+ "memchr",
+ "nix",
+ "num-format",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "strip-ansi-escapes",
+ "sys-locale",
+ "unicase",
+ "web-time",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "itoa",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "nuon"
+version = "0.112.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e30d56e18d6afeb6387e98b5a3411ef7af213a01de9ed0124ffcb8270116d3"
+dependencies = [
+ "nu-engine",
+ "nu-parser",
+ "nu-protocol",
+ "nu-utils",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "omnipath"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80adb31078122c880307e9cdfd4e3361e6545c319f9b9dcafcb03acd3b51a575"
 
 [[package]]
 name = "once_cell"
@@ -1037,6 +1669,21 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "os_display"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad5fd71b79026fb918650dde6d125000a233764f1c2f1659a1c71118e33ea08f"
+dependencies = [
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "parking_lot"
@@ -1169,12 +1816,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "procfs"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25485360a54d6861439d60facef26de713b1e126bf015ec8f98239467a2b82f7"
+dependencies = [
+ "bitflags",
+ "chrono",
+ "flate2",
+ "procfs-core",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6401bf7b6af22f78b563665d15a22e9aef27775b79b149a66ca022468a4e405"
+dependencies = [
+ "bitflags",
+ "chrono",
+ "hex",
 ]
 
 [[package]]
@@ -1195,6 +1888,22 @@ name = "pulldown-cmark-escape"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
+name = "pure-rust-locales"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "869675ad2d7541aea90c6d88c81f46a7f4ea9af8cd0395d38f11a95126998a0d"
+
+[[package]]
+name = "pwd"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c71c0c79b9701efe4e1e4b563b2016dd4ee789eb99badcb09d61ac4b92e4a2"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "quick-xml"
@@ -1218,6 +1927,8 @@ dependencies = [
  "hex",
  "indicatif",
  "leaves",
+ "nu-protocol",
+ "nuon",
  "ratatui",
  "semver",
  "serde",
@@ -1225,7 +1936,7 @@ dependencies = [
  "sha2",
  "syntect",
  "tar",
- "thiserror",
+ "thiserror 2.0.18",
  "toml",
  "walkdir",
  "xz2",
@@ -1259,10 +1970,10 @@ dependencies = [
  "crossterm 0.28.1",
  "indoc",
  "instability",
- "itertools",
- "lru",
+ "itertools 0.13.0",
+ "lru 0.12.5",
  "paste",
- "strum",
+ "strum 0.26.3",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.0",
@@ -1294,7 +2005,27 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1325,6 +2056,12 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -1387,6 +2124,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "self_cell"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"
@@ -1528,6 +2271,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1539,8 +2291,14 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
 ]
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 
 [[package]]
 name = "strum_macros"
@@ -1554,6 +2312,39 @@ dependencies = [
  "rustversion",
  "syn",
 ]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "supports-color"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
+dependencies = [
+ "is_ci",
+]
+
+[[package]]
+name = "supports-hyperlinks"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e396b6523b11ccb83120b115a0b7366de372751aa6edf19844dfb13a6af97e91"
+
+[[package]]
+name = "supports-unicode"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
@@ -1593,9 +2384,32 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "walkdir",
  "yaml-rust",
+]
+
+[[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
 ]
 
 [[package]]
@@ -1610,12 +2424,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "unicode-linebreak",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1676,6 +2530,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
+ "serde_core",
  "zerovec",
 ]
 
@@ -1768,10 +2623,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "type-map"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
+dependencies = [
+ "rustc-hash",
+]
+
+[[package]]
 name = "typed-path"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
@@ -1780,10 +2650,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "typetag"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2212c8a9b9bcfca32024de14998494cf9a5dfa59ea1b829de98bac374b86bf"
+dependencies = [
+ "erased-serde",
+ "inventory",
+ "once_cell",
+ "serde",
+ "typetag-impl",
+]
+
+[[package]]
+name = "typetag-impl"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27a7a9b72ba121f6f1f6c3632b85604cac41aedb5ddc70accbebb6cac83de846"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "unic-langid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ba52c9b05311f4f6e62d5d9d46f094bd6e84cb8df7b3ef952748d752a7d05"
+dependencies = [
+ "unic-langid-impl",
+]
+
+[[package]]
+name = "unic-langid-impl"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce1bf08044d4b7a94028c93786f8566047edc11110595914de93362559bc658"
+dependencies = [
+ "tinystr",
+]
 
 [[package]]
 name = "unicase"
@@ -1798,6 +2710,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1809,7 +2727,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
 dependencies = [
- "itertools",
+ "itertools 0.13.0",
  "unicode-segmentation",
  "unicode-width 0.1.14",
 ]
@@ -1869,6 +2787,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uucore"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07d779636d827cde4100f0e65ff3fd23b0b1f1195055475c6e6813d425f30c8e"
+dependencies = [
+ "clap",
+ "fluent",
+ "fluent-bundle",
+ "fluent-syntax",
+ "libc",
+ "nix",
+ "os_display",
+ "rustc-hash",
+ "rustix 1.1.4",
+ "thiserror 2.0.18",
+ "unic-langid",
+ "uucore_procs",
+ "wild",
+]
+
+[[package]]
+name = "uucore_procs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da865e8a648b260dbd89fca76d0801995877ab27a4e259b6dec30ba9743b86ab"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1885,6 +2834,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "walkdir"
@@ -1967,6 +2925,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wild"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3131afc8c575281e1e80f36ed6a092aa502c08b18ed7524e86fbbb12bb410e1"
+dependencies = [
+ "glob",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1998,10 +2965,105 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -2044,6 +3106,15 @@ dependencies = [
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -2164,6 +3235,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "zerofrom"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2201,6 +3293,7 @@ version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
+ "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1937,7 +1937,6 @@ dependencies = [
  "syntect",
  "tar",
  "thiserror 2.0.18",
- "toml",
  "walkdir",
  "xz2",
  "zip",
@@ -2178,15 +2177,6 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
-dependencies = [
- "serde_core",
 ]
 
 [[package]]
@@ -2533,45 +2523,6 @@ dependencies = [
  "serde_core",
  "zerovec",
 ]
-
-[[package]]
-name = "toml"
-version = "1.0.6+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399b1124a3c9e16766831c6bba21e50192572cdd98706ea114f9502509686ffc"
-dependencies = [
- "indexmap",
- "serde_core",
- "serde_spanned",
- "toml_datetime",
- "toml_parser",
- "toml_writer",
- "winnow",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "1.0.0+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
-dependencies = [
- "winnow",
-]
-
-[[package]]
-name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tracing"
@@ -3164,12 +3115,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ serde_json = "1"
 sha2 = "0.10"
 thiserror = "2"
 toml = "1.0.3"
+nuon = "0.112.2"
+nu-protocol = { version = "0.112.2", default-features = false }
 walkdir = "2"
 indicatif = "0.18.4"
 console = "0.16.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ semver = "1"
 serde_json = "1"
 sha2 = "0.10"
 thiserror = "2"
-toml = "1.0.3"
 nuon = "0.112.2"
 nu-protocol = { version = "0.112.2", default-features = false }
 walkdir = "2"

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ cargo install --git https://github.com/freepicheep/quiver
 
 A Quiver project is a directory containing:
 
-- **`nupackage.toml`** - declares package metadata and dependencies
+- **`nupackage.nuon`** - declares package metadata and dependencies
 - **`<project-dir-name>/mod.nu`** - the Nushell module entry point
 - **`quiver.lock`** - auto-generated lockfile pinning exact commits (commit this to version control)
 
@@ -89,7 +89,7 @@ qv add-plugin fdncred/nu_plugin_file --tag v0.22.0 --bin nu_plugin_file
 # Add a Nushell core plugin dependency by alias/name
 qv add-plugin polars
 
-# Install all dependencies from nupackage.toml
+# Install all dependencies from nupackage.nuon
 qv install
 
 # Run a Nushell script with quiver's environment (including any plugins)
@@ -114,7 +114,7 @@ qv update
 # Remove a dependency
 qv remove nu-salesforce
 
-# List installed dependencies (project-local if nupackage.toml exists, otherwise global)
+# List installed dependencies (project-local if nupackage.nuon exists, otherwise global)
 qv list
 
 # Generate editor LSP configuration (for helix and zed currently)
@@ -141,7 +141,7 @@ qvx --rev a3f9c12 freepicheep/nu-doc-gen generate-doc-site nu-salesforce .
 qvx --nu-version ">=0.109,<0.111" freepicheep/nu-doc-gen generate-doc-site nu-salesforce .
 ```
 
-The first argument is the module source (`owner/repo` shorthand or a git URL). The second argument is the command exported by that module. Everything after the command is passed through to the command. If `--nu-version` is supplied, qvx uses that Nushell version requirement for the ephemeral environment. Otherwise, if the remote module has a `nupackage.toml` with `package.nu-version`, qvx reuses that requirement. Internally, Quiver creates a cached ephemeral environment, installs the module there, starts the environment's Nu binary with that environment, and runs a generated wrapper equivalent to:
+The first argument is the module source (`owner/repo` shorthand or a git URL). The second argument is the command exported by that module. Everything after the command is passed through to the command. If `--nu-version` is supplied, qvx uses that Nushell version requirement for the ephemeral environment. Otherwise, if the remote module has a `nupackage.nuon` with `package.nu-version`, qvx reuses that requirement. Internally, Quiver creates a cached ephemeral environment, installs the module there, starts the environment's Nu binary with that environment, and runs a generated wrapper equivalent to:
 
 ```nushell
 use nu-doc-gen *
@@ -191,22 +191,27 @@ This generates:
 - **Helix**: `.helix/languages.toml` with a `nu-lsp` language server entry
 - **Zed**: `.zed/settings.json` with a `nu` language server binary config
 
-## nupackage.toml
+## nupackage.nuon
 
-```toml
-[package]
-name = "my-module"
-version = "0.1.0"
-description = "a wonderful nu module anyone can use"
-
-[dependencies.modules]
-nu-utils = { git = "https://github.com/user/nu-utils", tag = "v1.0.0" }
-other-lib = { git = "https://github.com/user/other-lib", branch = "main" }
-pinned = { git = "https://github.com/user/pinned", rev = "a3f9c12" }
-
-[dependencies.plugins]
-nu_plugin_inc = { git = "https://github.com/nushell/nu_plugin_inc", tag = "v0.91.0", bin = "nu_plugin_inc" }
-nu_plugin_polars = { source = "nu-core", bin = "nu_plugin_polars" }
+```nuon
+{
+  package: {
+    name: "my-module",
+    version: "0.1.0",
+    description: "a wonderful nu module anyone can use",
+  },
+  dependencies: {
+    modules: {
+      nu-utils: { git: "https://github.com/user/nu-utils", tag: "v1.0.0" },
+      other-lib: { git: "https://github.com/user/other-lib", branch: "main" },
+      pinned: { git: "https://github.com/user/pinned", rev: "a3f9c12" },
+    },
+    plugins: {
+      nu_plugin_inc: { git: "https://github.com/nushell/nu_plugin_inc", tag: "v0.91.0", bin: "nu_plugin_inc" },
+      nu_plugin_polars: { source: "nu-core", bin: "nu_plugin_polars" },
+    },
+  },
+}
 ```
 
 Module dependencies must specify exactly one of `tag`, `branch`, or `rev`.
@@ -218,10 +223,10 @@ Plugin dependencies support either:
 
 | Command | Description |
 |---------|-------------|
-| `qv init` | Create a new `nupackage.toml`, scaffold `<project-dir-name>/mod.nu`, and set up `.nu-env/` (supports `--nu-version`) |
+| `qv init` | Create a new `nupackage.nuon`, scaffold `<project-dir-name>/mod.nu`, and set up `.nu-env/` (supports `--nu-version`) |
 | `qv add <source>` | Add a module dependency from a URL or owner/repo shorthand (auto-detects latest tag) |
 | `qv add-plugin <source>` | Add a plugin dependency from git or Nushell core plugin alias/name |
-| `qv install` | Install dependencies from `nupackage.toml` and generate `.nu-env/` virtual environment |
+| `qv install` | Install dependencies from `nupackage.nuon` and generate `.nu-env/` virtual environment |
 | `qv install -g` | Install global dependencies from `~/.config/quiver/config.toml` |
 | `qv install --frozen` | Install from lockfile only (CI-friendly) |
 | `qv update` | Re-resolve all dependencies |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -71,7 +71,7 @@ struct QvxCli {
 
 #[derive(Subcommand, Debug)]
 pub enum Commands {
-    /// Create a new nupackage.toml in the current directory
+    /// Create a new nupackage.nuon in the current directory
     Init {
         /// Package name (defaults to current directory name)
         #[arg(long)]
@@ -90,7 +90,7 @@ pub enum Commands {
         description: Option<String>,
     },
 
-    /// Resolve and install dependencies from nupackage.toml
+    /// Resolve and install dependencies from nupackage.nuon
     Install {
         /// Install global modules (from ~/.config/quiver/config.toml)
         #[arg(short = 'g', long)]
@@ -114,7 +114,7 @@ pub enum Commands {
 
     /// Add a module dependency from a git URL or owner/repo shorthand
     Add {
-        /// Add to global config instead of local nupackage.toml
+        /// Add to global config instead of local nupackage.nuon
         #[arg(short = 'g', long)]
         global: bool,
 
@@ -136,7 +136,7 @@ pub enum Commands {
 
     /// Add a plugin dependency from a git URL or owner/repo shorthand
     AddPlugin {
-        /// Add to global config instead of local nupackage.toml
+        /// Add to global config instead of local nupackage.nuon
         #[arg(short = 'g', long)]
         global: bool,
 
@@ -160,10 +160,10 @@ pub enum Commands {
         bin: Option<String>,
     },
 
-    /// Remove a module dependency from nupackage.toml and .nu_modules/
+    /// Remove a module dependency from nupackage.nuon and .nu_modules/
     #[command(visible_alias = "rm")]
     Remove {
-        /// Remove from global config instead of local nupackage.toml
+        /// Remove from global config instead of local nupackage.nuon
         #[arg(short = 'g', long)]
         global: bool,
 
@@ -171,7 +171,7 @@ pub enum Commands {
         name: String,
     },
 
-    /// List installed dependencies (project-local if nupackage.toml exists, otherwise global modules)
+    /// List installed dependencies (project-local if nupackage.nuon exists, otherwise global modules)
     #[command(visible_alias = "ls")]
     List,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -92,7 +92,7 @@ pub enum Commands {
 
     /// Resolve and install dependencies from nupackage.nuon
     Install {
-        /// Install global modules (from ~/.config/quiver/config.toml)
+        /// Install global modules (from ~/.config/quiver/config.nuon)
         #[arg(short = 'g', long)]
         global: bool,
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,9 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use crate::error::{QuiverError, Result};
-use crate::manifest::{DependencySpec, PluginDependencySpec};
+use crate::manifest::{
+    nu_value_to_json, nuon_key, nuon_string, DependencySpec, PluginDependencySpec,
+};
 
 const DEFAULT_GIT_PROVIDER: &str = "github";
 
@@ -55,21 +57,7 @@ fn normalize_provider_base_url(provider: &str) -> Option<String> {
     None
 }
 
-fn toml_scalar<T: Serialize>(value: &T) -> Result<String> {
-    let scalar = toml::Value::try_from(value)
-        .map_err(|e| QuiverError::Config(format!("failed to encode TOML value: {e}")))?;
-    Ok(scalar.to_string())
-}
-
-fn install_mode_name(mode: InstallMode) -> &'static str {
-    match mode {
-        InstallMode::Clone => "clone",
-        InstallMode::Hardlink => "hardlink",
-        InstallMode::Copy => "copy",
-    }
-}
-
-/// The global quiver config file: `~/.config/quiver/config.toml`.
+/// The global quiver config file: `~/.config/quiver/config.nuon`.
 ///
 /// Tracks globally-installed modules and optional path overrides.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -80,7 +68,7 @@ pub enum InstallMode {
     Copy,
 }
 
-/// The global quiver config file: `~/.config/quiver/config.toml`.
+/// The global quiver config file: `~/.config/quiver/config.nuon`.
 ///
 /// Tracks globally-installed modules/plugins and optional path overrides.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -161,83 +149,73 @@ impl GlobalConfig {
     }
 
     fn load_from_path(path: &Path) -> Result<Self> {
-        let content = std::fs::read_to_string(&path)?;
-        let config: GlobalConfig = toml::from_str(&content)
-            .map_err(|e| QuiverError::Config(format!("failed to parse {}: {e}", path.display())))?;
-        Ok(config)
+        let content = std::fs::read_to_string(path)?;
+        let value = nuon::from_nuon(&content, None).map_err(|e| {
+            QuiverError::Config(format!("failed to parse {}: {e}", path.display()))
+        })?;
+        let json = nu_value_to_json(value).map_err(|e| {
+            QuiverError::Config(format!("failed to parse {}: {e}", path.display()))
+        })?;
+        serde_json::from_value(json)
+            .map_err(|e| QuiverError::Config(format!("failed to parse {}: {e}", path.display())))
     }
 
-    /// Serialize the global config using stable top-level `[modules]` and `[plugins]` tables.
-    pub fn to_toml_string(&self) -> Result<String> {
+    /// Serialize the global config to a NUON string with stable key ordering.
+    pub fn to_nuon_string(&self) -> String {
         let mut out = String::new();
+        out.push_str("{\n");
 
         if let Some(modules_dir) = &self.modules_dir {
-            out.push_str(&format!("modules_dir = {}\n", toml_scalar(modules_dir)?));
+            out.push_str(&format!("  modules_dir: {},\n", nuon_string(modules_dir)));
         }
         out.push_str(&format!(
-            "default_git_provider = {}\n",
-            toml_scalar(&self.default_git_provider)?
+            "  default_git_provider: {},\n",
+            nuon_string(&self.default_git_provider)
         ));
-        out.push_str(&format!(
-            "install_mode = {}\n",
-            toml_scalar(&install_mode_name(self.install_mode))?
-        ));
+        let mode_str = match self.install_mode {
+            InstallMode::Clone => "clone",
+            InstallMode::Hardlink => "hardlink",
+            InstallMode::Copy => "copy",
+        };
+        out.push_str(&format!("  install_mode: {},\n", nuon_string(mode_str)));
 
-        out.push_str("\n[security]\n");
+        out.push_str("  security: {\n");
         out.push_str(&format!(
-            "require_signed_assets = {}\n",
-            toml_scalar(&self.security.require_signed_assets)?
+            "    require_signed_assets: {},\n",
+            self.security.require_signed_assets
         ));
+        out.push_str("  },\n");
 
         if !self.modules.is_empty() {
-            out.push_str("\n[modules]\n");
+            out.push_str("  modules: {\n");
             let mut modules: Vec<_> = self.modules.iter().collect();
             modules.sort_by(|a, b| a.0.cmp(b.0));
             for (name, spec) in modules {
-                out.push_str(&format!("{name} = {{ git = {}, ", toml_scalar(&spec.git)?));
-                if let Some(tag) = &spec.tag {
-                    out.push_str(&format!("tag = {} }}\n", toml_scalar(tag)?));
-                } else if let Some(rev) = &spec.rev {
-                    out.push_str(&format!("rev = {} }}\n", toml_scalar(rev)?));
-                } else if let Some(branch) = &spec.branch {
-                    out.push_str(&format!("branch = {} }}\n", toml_scalar(branch)?));
-                } else {
-                    return Err(QuiverError::Config(format!(
-                        "module dependency '{name}' is missing tag/rev/branch"
-                    )));
-                }
+                out.push_str(&format!(
+                    "    {}: {{ {} }},\n",
+                    nuon_key(name),
+                    spec.to_inline_nuon()
+                ));
             }
+            out.push_str("  },\n");
         }
 
         if !self.plugins.is_empty() {
-            out.push_str("\n[plugins]\n");
+            out.push_str("  plugins: {\n");
             let mut plugins: Vec<_> = self.plugins.iter().collect();
             plugins.sort_by(|a, b| a.0.cmp(b.0));
             for (name, spec) in plugins {
-                let mut parts = Vec::new();
-                if let Some(source) = &spec.source {
-                    parts.push(format!("source = {}", toml_scalar(source)?));
-                }
-                if spec.source.as_deref() != Some("nu-core") {
-                    parts.push(format!("git = {}", toml_scalar(&spec.git)?));
-                }
-                if let Some(tag) = &spec.tag {
-                    parts.push(format!("tag = {}", toml_scalar(tag)?));
-                }
-                if let Some(rev) = &spec.rev {
-                    parts.push(format!("rev = {}", toml_scalar(rev)?));
-                }
-                if let Some(branch) = &spec.branch {
-                    parts.push(format!("branch = {}", toml_scalar(branch)?));
-                }
-                if let Some(bin) = &spec.bin {
-                    parts.push(format!("bin = {}", toml_scalar(bin)?));
-                }
-                out.push_str(&format!("{name} = {{ {} }}\n", parts.join(", ")));
+                out.push_str(&format!(
+                    "    {}: {{ {} }},\n",
+                    nuon_key(name),
+                    spec.to_inline_nuon()
+                ));
             }
+            out.push_str("  },\n");
         }
 
-        Ok(out)
+        out.push_str("}\n");
+        out
     }
 
     /// Save the global config back to disk.
@@ -248,7 +226,7 @@ impl GlobalConfig {
             std::fs::create_dir_all(parent)?;
         }
 
-        let content = self.to_toml_string()?;
+        let content = self.to_nuon_string();
         std::fs::write(&path, content)?;
         Ok(())
     }
@@ -296,7 +274,7 @@ pub fn global_config_dir() -> Result<PathBuf> {
 
 /// Returns the path to the global config file.
 pub fn global_config_path() -> Result<PathBuf> {
-    Ok(global_config_dir()?.join("config.toml"))
+    Ok(global_config_dir()?.join("config.nuon"))
 }
 
 /// Returns the path to the global lockfile.
@@ -369,6 +347,12 @@ pub fn global_modules_dir() -> Result<PathBuf> {
 mod tests {
     use super::*;
 
+    fn parse_nuon(s: &str) -> GlobalConfig {
+        let value = nuon::from_nuon(s, None).expect("nuon parse failed");
+        let json = nu_value_to_json(value).expect("json conversion failed");
+        serde_json::from_value(json).expect("serde_json parse failed")
+    }
+
     #[test]
     fn round_trip() {
         let config = GlobalConfig {
@@ -398,11 +382,11 @@ mod tests {
             )]),
         };
 
-        let serialized = config.to_toml_string().unwrap();
-        let parsed: GlobalConfig = toml::from_str(&serialized).unwrap();
+        let serialized = config.to_nuon_string();
+        let parsed = parse_nuon(&serialized);
 
-        assert!(serialized.contains("[modules]"));
-        assert!(!serialized.contains("[dependencies]"));
+        assert!(serialized.contains("modules:"));
+        assert!(!serialized.contains("dependencies:"));
         assert_eq!(parsed.modules.len(), 1);
         assert!(parsed.modules.contains_key("nu-utils"));
         assert!(parsed.plugins.contains_key("nu_plugin_inc"));
@@ -422,8 +406,8 @@ mod tests {
             plugins: HashMap::new(),
         };
 
-        let serialized = config.to_toml_string().unwrap();
-        let parsed: GlobalConfig = toml::from_str(&serialized).unwrap();
+        let serialized = config.to_nuon_string();
+        let parsed = parse_nuon(&serialized);
 
         assert_eq!(parsed.modules_dir.as_deref(), Some("/custom/path"));
         assert_eq!(parsed.default_git_provider, "gitlab");
@@ -472,7 +456,7 @@ mod tests {
         assert_eq!(dir, expected_dir);
 
         let path = global_config_path().unwrap();
-        assert_eq!(path, expected_dir.join("config.toml"));
+        assert_eq!(path, expected_dir.join("config.nuon"));
 
         let lock = global_lock_path().unwrap();
         assert_eq!(lock, expected_dir.join("config.lock"));
@@ -501,12 +485,12 @@ mod tests {
 
     #[test]
     fn missing_provider_defaults_to_github() {
-        let toml = r#"
-modules_dir = "/tmp/quiver-modules"
-
-[modules]
+        let nuon = r#"
+{
+  modules_dir: "/tmp/quiver-modules",
+}
 "#;
-        let parsed: GlobalConfig = toml::from_str(toml).unwrap();
+        let parsed = parse_nuon(nuon);
         assert_eq!(parsed.default_git_provider, "github");
         assert_eq!(parsed.install_mode, default_install_mode());
         assert!(parsed.security.require_signed_assets);
@@ -514,13 +498,15 @@ modules_dir = "/tmp/quiver-modules"
 
     #[test]
     fn legacy_dependencies_table_still_parses_into_modules() {
-        let toml = r#"
-modules_dir = "/tmp/quiver-modules"
-
-[dependencies]
-nu-utils = { git = "https://github.com/user/nu-utils", tag = "v1.0.0" }
+        let nuon = r#"
+{
+  modules_dir: "/tmp/quiver-modules",
+  dependencies: {
+    "nu-utils": { git: "https://github.com/user/nu-utils", tag: "v1.0.0" },
+  },
+}
 "#;
-        let parsed: GlobalConfig = toml::from_str(toml).unwrap();
+        let parsed = parse_nuon(nuon);
         assert!(parsed.modules.contains_key("nu-utils"));
     }
 
@@ -580,8 +566,8 @@ nu-utils = { git = "https://github.com/user/nu-utils", tag = "v1.0.0" }
             plugins: HashMap::new(),
         };
 
-        let serialized = config.to_toml_string().unwrap();
-        let parsed: GlobalConfig = toml::from_str(&serialized).unwrap();
+        let serialized = config.to_nuon_string();
+        let parsed = parse_nuon(&serialized);
         assert_eq!(parsed.install_mode, InstallMode::Hardlink);
     }
 
@@ -598,8 +584,8 @@ nu-utils = { git = "https://github.com/user/nu-utils", tag = "v1.0.0" }
             plugins: HashMap::new(),
         };
 
-        let serialized = config.to_toml_string().unwrap();
-        let parsed: GlobalConfig = toml::from_str(&serialized).unwrap();
+        let serialized = config.to_nuon_string();
+        let parsed = parse_nuon(&serialized);
         assert!(!parsed.security.require_signed_assets);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,8 +4,9 @@ use std::path::{Path, PathBuf};
 
 use crate::error::{QuiverError, Result};
 use crate::manifest::{
-    nu_value_to_json, nuon_key, nuon_string, DependencySpec, PluginDependencySpec,
+    DependencySpec, PluginDependencySpec, nu_value_to_json, nuon_key, nuon_string,
 };
+use crate::ui;
 
 const DEFAULT_GIT_PROVIDER: &str = "github";
 
@@ -129,6 +130,7 @@ impl GlobalConfig {
         let path = global_config_path()?;
 
         if !path.exists() {
+            warn_if_legacy_toml_config(&path);
             let config = GlobalConfig::default();
             config.save()?;
             return Ok(config);
@@ -142,6 +144,7 @@ impl GlobalConfig {
         let path = global_config_path()?;
 
         if !path.exists() {
+            warn_if_legacy_toml_config(&path);
             return Ok(GlobalConfig::default());
         }
 
@@ -150,12 +153,10 @@ impl GlobalConfig {
 
     fn load_from_path(path: &Path) -> Result<Self> {
         let content = std::fs::read_to_string(path)?;
-        let value = nuon::from_nuon(&content, None).map_err(|e| {
-            QuiverError::Config(format!("failed to parse {}: {e}", path.display()))
-        })?;
-        let json = nu_value_to_json(value).map_err(|e| {
-            QuiverError::Config(format!("failed to parse {}: {e}", path.display()))
-        })?;
+        let value = nuon::from_nuon(&content, None)
+            .map_err(|e| QuiverError::Config(format!("failed to parse {}: {e}", path.display())))?;
+        let json = nu_value_to_json(value)
+            .map_err(|e| QuiverError::Config(format!("failed to parse {}: {e}", path.display())))?;
         serde_json::from_value(json)
             .map_err(|e| QuiverError::Config(format!("failed to parse {}: {e}", path.display())))
     }
@@ -251,6 +252,23 @@ impl GlobalConfig {
                 self.default_git_provider
             ))
         })
+    }
+}
+
+fn warn_if_legacy_toml_config(nuon_path: &Path) {
+    let toml_path = nuon_path.with_extension("toml");
+    if toml_path.exists() {
+        ui::warn("config.toml detected but quiver now requires config.nuon. Migrate with:");
+        eprintln!();
+        eprintln!(
+            "  open {} | to nuon --indent 2 | save -f {}",
+            toml_path.display(),
+            nuon_path.display()
+        );
+        eprintln!("  rm {}", toml_path.display());
+        eprintln!("  rm {}", nuon_path.with_file_name("config.lock").display());
+        eprintln!("  qv install -g");
+        eprintln!();
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,11 +21,14 @@ pub enum QuiverError {
     #[error("config error: {0}")]
     Config(String),
 
-    #[error("no nupackage.toml found in {0}")]
+    #[error("no nupackage.nuon found in {0}")]
     NoManifest(PathBuf),
 
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
+
+    #[error("nuon parse error: {0}")]
+    NuonParse(#[from] nu_protocol::ShellError),
 
     #[error("toml parse error: {0}")]
     TomlParse(#[from] toml::de::Error),

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,12 +30,6 @@ pub enum QuiverError {
     #[error("nuon parse error: {0}")]
     NuonParse(#[from] nu_protocol::ShellError),
 
-    #[error("toml parse error: {0}")]
-    TomlParse(#[from] toml::de::Error),
-
-    #[error("toml serialize error: {0}")]
-    TomlSerialize(#[from] toml::ser::Error),
-
     #[error("checksum source not found for asset '{asset}': {details}")]
     ChecksumSourceNotFound { asset: String, details: String },
 

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -4038,15 +4038,18 @@ mod tests {
         )
         .unwrap();
         let lockfile = Lockfile::from_str(
-            r#"version = 1
-
-[[package]]
-name = "other-module"
-git = "https://github.com/example/other"
-tag = "v1.0.0"
-rev = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-sha256 = "aaa"
-"#,
+            r#"{
+  version: 1,
+  packages: [
+    {
+      name: "other-module",
+      git: "https://github.com/example/other",
+      tag: "v1.0.0",
+      rev: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      sha256: "aaa",
+    },
+  ],
+}"#,
         )
         .unwrap();
 
@@ -4060,23 +4063,26 @@ sha256 = "aaa"
         )
         .unwrap();
         let lockfile = Lockfile::from_str(
-            r#"version = 1
-
-[[package]]
-name = "nu-salesforce"
-git = "https://github.com/freepicheep/nu-salesforce"
-tag = "v0.3.0"
-rev = "cccccccccccccccccccccccccccccccccccccccc"
-sha256 = "ccc"
-
-[[package]]
-name = "future"
-kind = "plugin"
-git = "https://github.com/example/future"
-tag = "v1.0.0"
-rev = "dddddddddddddddddddddddddddddddddddddddd"
-sha256 = "ddd"
-"#,
+            r#"{
+  version: 1,
+  packages: [
+    {
+      name: "nu-salesforce",
+      git: "https://github.com/freepicheep/nu-salesforce",
+      tag: "v0.3.0",
+      rev: "cccccccccccccccccccccccccccccccccccccccc",
+      sha256: "ccc",
+    },
+    {
+      name: "future",
+      kind: "plugin",
+      git: "https://github.com/example/future",
+      tag: "v1.0.0",
+      rev: "dddddddddddddddddddddddddddddddddddddddd",
+      sha256: "ddd",
+    },
+  ],
+}"#,
         )
         .unwrap();
 
@@ -4090,15 +4096,18 @@ sha256 = "ddd"
         )
         .unwrap();
         let lockfile = Lockfile::from_str(
-            r#"version = 1
-
-[[package]]
-name = "nu-salesforce"
-git = "https://github.com/freepicheep/nu-salesforce"
-tag = "v0.3.0"
-rev = "cccccccccccccccccccccccccccccccccccccccc"
-sha256 = "ccc"
-"#,
+            r#"{
+  version: 1,
+  packages: [
+    {
+      name: "nu-salesforce",
+      git: "https://github.com/freepicheep/nu-salesforce",
+      tag: "v0.3.0",
+      rev: "cccccccccccccccccccccccccccccccccccccccc",
+      sha256: "ccc",
+    },
+  ],
+}"#,
         )
         .unwrap();
 
@@ -4112,17 +4121,20 @@ sha256 = "ccc"
         )
         .unwrap();
         let lockfile = Lockfile::from_str(
-            r#"version = 1
-
-[[package]]
-name = "nu_plugin_inc"
-kind = "plugin"
-git = "https://github.com/nushell/nu_plugin_inc"
-tag = "v0.91.0"
-rev = "dddddddddddddddddddddddddddddddddddddddd"
-path = "nu_plugin_inc"
-sha256 = "ddd"
-"#,
+            r#"{
+  version: 1,
+  packages: [
+    {
+      name: "nu_plugin_inc",
+      kind: "plugin",
+      git: "https://github.com/nushell/nu_plugin_inc",
+      tag: "v0.91.0",
+      rev: "dddddddddddddddddddddddddddddddddddddddd",
+      path: "nu_plugin_inc",
+      sha256: "ddd",
+    },
+  ],
+}"#,
         )
         .unwrap();
 
@@ -4136,16 +4148,19 @@ sha256 = "ddd"
         )
         .unwrap();
         let lockfile = Lockfile::from_str(
-            r#"version = 1
-
-[[package]]
-name = "nu_plugin_polars"
-kind = "plugin"
-git = "nu-core"
-rev = "nu-0.111.0"
-path = "nu_plugin_polars"
-sha256 = "ddd"
-"#,
+            r#"{
+  version: 1,
+  packages: [
+    {
+      name: "nu_plugin_polars",
+      kind: "plugin",
+      git: "nu-core",
+      rev: "nu-0.111.0",
+      path: "nu_plugin_polars",
+      sha256: "ddd",
+    },
+  ],
+}"#,
         )
         .unwrap();
 
@@ -4159,16 +4174,19 @@ sha256 = "ddd"
         )
         .unwrap();
         let lockfile = Lockfile::from_str(
-            r#"version = 1
-
-[[package]]
-name = "nu_plugin_polars"
-kind = "plugin"
-git = "nu-core"
-rev = "nu-0.111.0"
-path = "nu_plugin_polars"
-sha256 = "ddd"
-"#,
+            r#"{
+  version: 1,
+  packages: [
+    {
+      name: "nu_plugin_polars",
+      kind: "plugin",
+      git: "nu-core",
+      rev: "nu-0.111.0",
+      path: "nu_plugin_polars",
+      sha256: "ddd",
+    },
+  ],
+}"#,
         )
         .unwrap();
 
@@ -4211,15 +4229,18 @@ sha256 = "ddd"
     #[test]
     fn resolved_module_matches_existing_lock_requires_exact_resolved_identity() {
         let lockfile = Lockfile::from_str(
-            r#"version = 1
-
-[[package]]
-name = "nu-salesforce"
-git = "https://github.com/freepicheep/nu-salesforce"
-tag = "v0.1.0"
-rev = "307444896bd7feedfacecafebeef1234567890ab"
-sha256 = "abc"
-"#,
+            r#"{
+  version: 1,
+  packages: [
+    {
+      name: "nu-salesforce",
+      git: "https://github.com/freepicheep/nu-salesforce",
+      tag: "v0.1.0",
+      rev: "307444896bd7feedfacecafebeef1234567890ab",
+      sha256: "abc",
+    },
+  ],
+}"#,
         )
         .unwrap();
         let matching = ResolvedDep {
@@ -4246,17 +4267,20 @@ sha256 = "abc"
     #[test]
     fn resolved_plugin_matches_existing_lock_checks_bin_and_ref() {
         let lockfile = Lockfile::from_str(
-            r#"version = 1
-
-[[package]]
-name = "nu_plugin_file"
-kind = "plugin"
-git = "https://github.com/fdncred/nu_plugin_file"
-tag = "v0.22.0"
-rev = "1234567890abcdef1234567890abcdef12345678"
-path = "nu_plugin_file"
-sha256 = "def"
-"#,
+            r#"{
+  version: 1,
+  packages: [
+    {
+      name: "nu_plugin_file",
+      kind: "plugin",
+      git: "https://github.com/fdncred/nu_plugin_file",
+      tag: "v0.22.0",
+      rev: "1234567890abcdef1234567890abcdef12345678",
+      path: "nu_plugin_file",
+      sha256: "def",
+    },
+  ],
+}"#,
         )
         .unwrap();
         let matching = ResolvedPlugin {
@@ -4292,16 +4316,19 @@ sha256 = "def"
     #[test]
     fn resolved_plugin_matches_existing_lock_allows_nu_core_versioned_lock_entries() {
         let lockfile = Lockfile::from_str(
-            r#"version = 1
-
-[[package]]
-name = "nu_plugin_polars"
-kind = "plugin"
-git = "nu-core"
-rev = "nu-0.111.0"
-path = "nu_plugin_polars"
-sha256 = "ghi"
-"#,
+            r#"{
+  version: 1,
+  packages: [
+    {
+      name: "nu_plugin_polars",
+      kind: "plugin",
+      git: "nu-core",
+      rev: "nu-0.111.0",
+      path: "nu_plugin_polars",
+      sha256: "ghi",
+    },
+  ],
+}"#,
         )
         .unwrap();
         let plugin = ResolvedPlugin {
@@ -4365,16 +4392,18 @@ sha256 = "ghi"
         std::fs::write(
             project_dir.join("quiver.lock"),
             r#"# This file is generated automatically. Do not edit.
-version = 1
-
-[[package]]
-name = "nu-utils"
-kind = "module"
-git = "https://github.com/example/nu-utils"
-tag = "v1.0.0"
-rev = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-sha256 = "aaa"
-"#,
+{
+  version: 1,
+  packages: [
+    {
+      name: "nu-utils",
+      git: "https://github.com/example/nu-utils",
+      tag: "v1.0.0",
+      rev: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      sha256: "aaa",
+    },
+  ],
+}"#,
         )
         .unwrap();
 
@@ -4396,15 +4425,18 @@ sha256 = "aaa"
         let lock_path = root.join("config.lock");
         std::fs::write(
             &lock_path,
-            r#"version = 1
-
-[[package]]
-name = "other"
-git = "https://github.com/example/other"
-tag = "v1.0.0"
-rev = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-sha256 = "aaa"
-"#,
+            r#"{
+  version: 1,
+  packages: [
+    {
+      name: "other",
+      git: "https://github.com/example/other",
+      tag: "v1.0.0",
+      rev: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      sha256: "aaa",
+    },
+  ],
+}"#,
         )
         .unwrap();
 
@@ -4435,15 +4467,18 @@ sha256 = "aaa"
         let lock_path = root.join("config.lock");
         std::fs::write(
             &lock_path,
-            r#"version = 1
-
-[[package]]
-name = "nu-utils"
-git = "https://github.com/example/nu-utils"
-tag = "v1.0.0"
-rev = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-sha256 = "aaa"
-"#,
+            r#"{
+  version: 1,
+  packages: [
+    {
+      name: "nu-utils",
+      git: "https://github.com/example/nu-utils",
+      tag: "v1.0.0",
+      rev: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      sha256: "aaa",
+    },
+  ],
+}"#,
         )
         .unwrap();
 
@@ -4474,15 +4509,18 @@ sha256 = "aaa"
         let lock_path = root.join("config.lock");
         std::fs::write(
             &lock_path,
-            r#"version = 1
-
-[[package]]
-name = "nu-utils"
-git = "https://github.com/example/nu-utils"
-tag = "v1.0.0"
-rev = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-sha256 = "aaa"
-"#,
+            r#"{
+  version: 1,
+  packages: [
+    {
+      name: "nu-utils",
+      git: "https://github.com/example/nu-utils",
+      tag: "v1.0.0",
+      rev: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      sha256: "aaa",
+    },
+  ],
+}"#,
         )
         .unwrap();
 
@@ -4515,17 +4553,20 @@ sha256 = "aaa"
         let lock_path = root.join("config.lock");
         std::fs::write(
             &lock_path,
-            r#"version = 1
-
-[[package]]
-name = "nu_plugin_inc"
-kind = "plugin"
-git = "https://github.com/nushell/nu_plugin_inc"
-tag = "v0.91.0"
-rev = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-path = "nu_plugin_inc"
-sha256 = "aaa"
-"#,
+            r#"{
+  version: 1,
+  packages: [
+    {
+      name: "nu_plugin_inc",
+      kind: "plugin",
+      git: "https://github.com/nushell/nu_plugin_inc",
+      tag: "v0.91.0",
+      rev: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      path: "nu_plugin_inc",
+      sha256: "aaa",
+    },
+  ],
+}"#,
         )
         .unwrap();
 

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -97,7 +97,7 @@ pub fn install_with_options(
 
     let has_no_dependencies = manifest.dependencies.is_empty();
     if has_no_dependencies {
-        ui::warn("No dependencies declared in nupackage.toml.");
+        ui::warn("No dependencies declared in nupackage.nuon.");
     }
 
     // Determine whether to re-resolve or use the lockfile
@@ -3281,7 +3281,7 @@ fn should_include_root_peripheral_file(name: &str) -> bool {
             | "authors"
             | "security"
             | "code_of_conduct"
-            | "nupackage"
+            | "nuproject"
             | "nupm"
     ) || name.ends_with(".md")
         || name.ends_with(".rst")
@@ -4034,13 +4034,7 @@ mod tests {
     #[test]
     fn local_lockfile_staleness_detects_module_mismatches() {
         let manifest = Manifest::from_str(
-            r#"[package]
-name = "demo"
-version = "0.1.0"
-
-[dependencies.modules]
-nu-salesforce = { git = "https://github.com/freepicheep/nu-salesforce", tag = "v0.3.0" }
-"#,
+            r#"{ package: { name: "demo", version: "0.1.0" }, dependencies: { modules: { nu-salesforce: { git: "https://github.com/freepicheep/nu-salesforce", tag: "v0.3.0" } } } }"#,
         )
         .unwrap();
         let lockfile = Lockfile::from_str(
@@ -4062,13 +4056,7 @@ sha256 = "aaa"
     #[test]
     fn local_lockfile_staleness_detects_unknown_artifacts() {
         let manifest = Manifest::from_str(
-            r#"[package]
-name = "demo"
-version = "0.1.0"
-
-[dependencies.modules]
-nu-salesforce = { git = "https://github.com/freepicheep/nu-salesforce", tag = "v0.3.0" }
-"#,
+            r#"{ package: { name: "demo", version: "0.1.0" }, dependencies: { modules: { nu-salesforce: { git: "https://github.com/freepicheep/nu-salesforce", tag: "v0.3.0" } } } }"#,
         )
         .unwrap();
         let lockfile = Lockfile::from_str(
@@ -4098,13 +4086,7 @@ sha256 = "ddd"
     #[test]
     fn local_lockfile_staleness_detects_changed_module_ref() {
         let manifest = Manifest::from_str(
-            r#"[package]
-name = "demo"
-version = "0.1.0"
-
-[dependencies.modules]
-nu-salesforce = { git = "https://github.com/freepicheep/nu-salesforce", tag = "v0.4.0" }
-"#,
+            r#"{ package: { name: "demo", version: "0.1.0" }, dependencies: { modules: { nu-salesforce: { git: "https://github.com/freepicheep/nu-salesforce", tag: "v0.4.0" } } } }"#,
         )
         .unwrap();
         let lockfile = Lockfile::from_str(
@@ -4126,13 +4108,7 @@ sha256 = "ccc"
     #[test]
     fn local_lockfile_staleness_detects_changed_plugin_bin() {
         let manifest = Manifest::from_str(
-            r#"[package]
-name = "demo"
-version = "0.1.0"
-
-[dependencies.plugins]
-nu_plugin_inc = { git = "https://github.com/nushell/nu_plugin_inc", tag = "v0.91.0", bin = "nu_plugin_inc_v2" }
-"#,
+            r#"{ package: { name: "demo", version: "0.1.0" }, dependencies: { plugins: { nu_plugin_inc: { git: "https://github.com/nushell/nu_plugin_inc", tag: "v0.91.0", bin: "nu_plugin_inc_v2" } } } }"#,
         )
         .unwrap();
         let lockfile = Lockfile::from_str(
@@ -4156,14 +4132,7 @@ sha256 = "ddd"
     #[test]
     fn local_lockfile_staleness_detects_changed_exact_nu_version_for_core_plugin() {
         let manifest = Manifest::from_str(
-            r#"[package]
-name = "demo"
-version = "0.1.0"
-nu-version = "0.110.0"
-
-[dependencies.plugins]
-nu_plugin_polars = { source = "nu-core", bin = "nu_plugin_polars" }
-"#,
+            r#"{ package: { name: "demo", version: "0.1.0", nu-version: "0.110.0" }, dependencies: { plugins: { nu_plugin_polars: { source: "nu-core", bin: "nu_plugin_polars" } } } }"#,
         )
         .unwrap();
         let lockfile = Lockfile::from_str(
@@ -4186,14 +4155,7 @@ sha256 = "ddd"
     #[test]
     fn local_lockfile_staleness_keeps_range_nu_version_for_core_plugin() {
         let manifest = Manifest::from_str(
-            r#"[package]
-name = "demo"
-version = "0.1.0"
-nu-version = ">=0.110.0, <0.112.0"
-
-[dependencies.plugins]
-nu_plugin_polars = { source = "nu-core", bin = "nu_plugin_polars" }
-"#,
+            r#"{ package: { name: "demo", version: "0.1.0", nu-version: ">=0.110.0, <0.112.0" }, dependencies: { plugins: { nu_plugin_polars: { source: "nu-core", bin: "nu_plugin_polars" } } } }"#,
         )
         .unwrap();
         let lockfile = Lockfile::from_str(
@@ -4364,11 +4326,8 @@ sha256 = "ghi"
             .and_then(detect_nu_binary_version)
             .map(|version| seed_fake_nu_store(&version.to_string()));
         std::fs::write(
-            project_dir.join("nupackage.toml"),
-            r#"[package]
-name = "demo"
-version = "0.1.0"
-"#,
+            project_dir.join("nupackage.nuon"),
+            r#"{ package: { name: "demo", version: "0.1.0" } }"#,
         )
         .unwrap();
 
@@ -4398,11 +4357,8 @@ version = "0.1.0"
             .and_then(detect_nu_binary_version)
             .map(|version| seed_fake_nu_store(&version.to_string()));
         std::fs::write(
-            project_dir.join("nupackage.toml"),
-            r#"[package]
-name = "demo"
-version = "0.1.0"
-"#,
+            project_dir.join("nupackage.nuon"),
+            r#"{ package: { name: "demo", version: "0.1.0" } }"#,
         )
         .unwrap();
 
@@ -4955,15 +4911,13 @@ sha256 = "aaa"
     fn local_lockfile_staleness_detects_missing_plugin_entry() {
         let manifest = Manifest::from_str(
             r#"
-[package]
-name = "demo"
-version = "0.1.0"
-
-[dependencies.modules]
-nu-utils = { git = "https://github.com/example/nu-utils", tag = "v1.0.0" }
-
-[dependencies.plugins]
-nu_plugin_inc = { git = "https://github.com/nushell/nu_plugin_inc", tag = "v0.91.0", bin = "nu_plugin_inc" }
+{
+  package: { name: "demo", version: "0.1.0" },
+  dependencies: {
+    modules: { nu-utils: { git: "https://github.com/example/nu-utils", tag: "v1.0.0" } },
+    plugins: { nu_plugin_inc: { git: "https://github.com/nushell/nu_plugin_inc", tag: "v0.91.0", bin: "nu_plugin_inc" } },
+  },
+}
 "#,
         )
         .unwrap();

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -88,7 +88,11 @@ impl Lockfile {
             }
             out.push_str(&format!("      rev: {},\n", nuon_string(&pkg.rev)));
             if let Some(path) = &pkg.path {
-                out.push_str(&format!("      {}: {},\n", nuon_key("path"), nuon_string(path)));
+                out.push_str(&format!(
+                    "      {}: {},\n",
+                    nuon_key("path"),
+                    nuon_string(path)
+                ));
             }
             out.push_str(&format!("      sha256: {},\n", nuon_string(&pkg.sha256)));
             if let Some(asset_sha256) = &pkg.asset_sha256 {

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1,13 +1,13 @@
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
-use crate::error::Result;
+use crate::error::{QuiverError, Result};
+use crate::manifest::{nu_value_to_json, nuon_key, nuon_string};
 
 /// The `quiver.lock` lockfile.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Lockfile {
     pub version: u32,
-    #[serde(rename = "package")]
     pub packages: Vec<LockedPackage>,
 }
 
@@ -56,22 +56,60 @@ impl Lockfile {
         Self::from_str(&content)
     }
 
-    /// Parse a lockfile from a TOML string.
+    /// Parse a lockfile from a NUON string.
     pub fn from_str(s: &str) -> Result<Self> {
-        Ok(toml::from_str(s)?)
+        let value = nuon::from_nuon(s, None)?;
+        let json = nu_value_to_json(value)?;
+        serde_json::from_value(json)
+            .map_err(|e| QuiverError::Lockfile(format!("invalid lockfile schema: {e}")))
     }
 
-    /// Serialize the lockfile to a TOML string with the header comment.
-    pub fn to_toml_string(&self) -> Result<String> {
-        let body = toml::to_string_pretty(self)?;
-        Ok(format!(
-            "# This file is generated automatically. Do not edit.\n{body}"
-        ))
+    /// Serialize the lockfile to a NUON string with the header comment.
+    pub fn to_nuon_string(&self) -> String {
+        let mut out = String::new();
+        out.push_str("# This file is generated automatically. Do not edit.\n");
+        out.push_str("{\n");
+        out.push_str(&format!("  version: {},\n", self.version));
+        out.push_str("  packages: [\n");
+        for pkg in &self.packages {
+            out.push_str("    {\n");
+            out.push_str(&format!("      name: {},\n", nuon_string(&pkg.name)));
+            if !LockedPackageKind::is_module(&pkg.kind) {
+                let kind_str = match pkg.kind {
+                    LockedPackageKind::Plugin => "plugin",
+                    LockedPackageKind::Other => "other",
+                    LockedPackageKind::Module => unreachable!(),
+                };
+                out.push_str(&format!("      kind: {},\n", nuon_string(kind_str)));
+            }
+            out.push_str(&format!("      git: {},\n", nuon_string(&pkg.git)));
+            if let Some(tag) = &pkg.tag {
+                out.push_str(&format!("      tag: {},\n", nuon_string(tag)));
+            }
+            out.push_str(&format!("      rev: {},\n", nuon_string(&pkg.rev)));
+            if let Some(path) = &pkg.path {
+                out.push_str(&format!("      {}: {},\n", nuon_key("path"), nuon_string(path)));
+            }
+            out.push_str(&format!("      sha256: {},\n", nuon_string(&pkg.sha256)));
+            if let Some(asset_sha256) = &pkg.asset_sha256 {
+                out.push_str(&format!(
+                    "      asset_sha256: {},\n",
+                    nuon_string(asset_sha256)
+                ));
+            }
+            if let Some(asset_url) = &pkg.asset_url {
+                out.push_str(&format!("      asset_url: {},\n", nuon_string(asset_url)));
+            }
+            out.push_str("    },\n");
+        }
+        out.push_str("  ],\n");
+        out.push_str("}\n");
+        out
     }
 
     /// Write the lockfile to disk.
     pub fn write_to(&self, path: &Path) -> Result<()> {
-        let content = self.to_toml_string()?;
+        let content = self.to_nuon_string();
         std::fs::write(path, content)?;
         Ok(())
     }
@@ -137,9 +175,7 @@ mod tests {
     #[test]
     fn round_trip() {
         let lock = sample_lockfile();
-        let serialized = lock.to_toml_string().unwrap();
-
-        // The header comment is not part of the TOML data, strip it for parsing
+        let serialized = lock.to_nuon_string();
         let parsed = Lockfile::from_str(&serialized).unwrap();
         assert_eq!(lock, parsed);
     }
@@ -162,18 +198,22 @@ mod tests {
 
     #[test]
     fn parse_spec_format() {
-        let toml = r#"
+        let nuon = r#"
 # This file is generated automatically. Do not edit.
-version = 1
-
-[[package]]
-name = "nu-git-utils"
-git = "https://github.com/someuser/nu-git-utils"
-tag = "v0.2.0"
-rev = "d4e8f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8"
-sha256 = "abc123"
+{
+  version: 1,
+  packages: [
+    {
+      name: "nu-git-utils",
+      git: "https://github.com/someuser/nu-git-utils",
+      tag: "v0.2.0",
+      rev: "d4e8f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8",
+      sha256: "abc123",
+    },
+  ],
+}
 "#;
-        let lock = Lockfile::from_str(toml).unwrap();
+        let lock = Lockfile::from_str(nuon).unwrap();
         assert_eq!(lock.version, 1);
         assert_eq!(lock.packages.len(), 1);
         assert_eq!(lock.packages[0].name, "nu-git-utils");
@@ -182,39 +222,47 @@ sha256 = "abc123"
 
     #[test]
     fn parse_plugin_kind() {
-        let toml = r#"
-version = 1
-
-[[package]]
-name = "nu_plugin_inc"
-kind = "plugin"
-git = "https://github.com/nushell/nu_plugin_inc"
-tag = "v0.91.0"
-rev = "9a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b"
-path = "nu_plugin_inc"
-sha256 = "ghi789"
+        let nuon = r#"
+{
+  version: 1,
+  packages: [
+    {
+      name: "nu_plugin_inc",
+      kind: "plugin",
+      git: "https://github.com/nushell/nu_plugin_inc",
+      tag: "v0.91.0",
+      rev: "9a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b",
+      path: "nu_plugin_inc",
+      sha256: "ghi789",
+    },
+  ],
+}
 "#;
-        let lock = Lockfile::from_str(toml).unwrap();
+        let lock = Lockfile::from_str(nuon).unwrap();
         assert_eq!(lock.packages[0].kind, LockedPackageKind::Plugin);
     }
 
     #[test]
     fn parse_optional_asset_metadata() {
-        let toml = r#"
-version = 1
-
-[[package]]
-name = "nu_plugin_inc"
-kind = "plugin"
-git = "https://github.com/nushell/nu_plugin_inc"
-tag = "v0.91.0"
-rev = "9a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b"
-path = "nu_plugin_inc"
-sha256 = "ghi789"
-asset_sha256 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-asset_url = "https://example.com/nu_plugin_inc.tar.gz"
+        let nuon = r#"
+{
+  version: 1,
+  packages: [
+    {
+      name: "nu_plugin_inc",
+      kind: "plugin",
+      git: "https://github.com/nushell/nu_plugin_inc",
+      tag: "v0.91.0",
+      rev: "9a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b",
+      path: "nu_plugin_inc",
+      sha256: "ghi789",
+      asset_sha256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      asset_url: "https://example.com/nu_plugin_inc.tar.gz",
+    },
+  ],
+}
 "#;
-        let lock = Lockfile::from_str(toml).unwrap();
+        let lock = Lockfile::from_str(nuon).unwrap();
         assert_eq!(
             lock.packages[0].asset_sha256.as_deref(),
             Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
@@ -227,18 +275,22 @@ asset_url = "https://example.com/nu_plugin_inc.tar.gz"
 
     #[test]
     fn parse_unknown_kind_as_other() {
-        let toml = r#"
-version = 1
-
-[[package]]
-name = "future-artifact"
-kind = "futurekind"
-git = "https://github.com/someuser/future"
-tag = "v0.5.0"
-rev = "9a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b"
-sha256 = "ghi789"
+        let nuon = r#"
+{
+  version: 1,
+  packages: [
+    {
+      name: "future-artifact",
+      kind: "futurekind",
+      git: "https://github.com/someuser/future",
+      tag: "v0.5.0",
+      rev: "9a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b",
+      sha256: "ghi789",
+    },
+  ],
+}
 "#;
-        let lock = Lockfile::from_str(toml).unwrap();
+        let lock = Lockfile::from_str(nuon).unwrap();
         assert_eq!(lock.packages[0].kind, LockedPackageKind::Other);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,10 +176,10 @@ fn cmd_init(
     nu_version: Option<String>,
     description: Option<String>,
 ) -> Result<()> {
-    let nupackage_toml = dir.join("nupackage.toml");
-    if nupackage_toml.exists() {
+    let manifest_path = dir.join("nupackage.nuon");
+    if manifest_path.exists() {
         return Err(error::QuiverError::Manifest(
-            "nupackage.toml already exists in this directory".to_string(),
+            "nupackage.nuon already exists in this directory".to_string(),
         ));
     }
 
@@ -210,9 +210,9 @@ fn cmd_init(
         dependencies: Default::default(),
     };
 
-    let content = manifest.to_toml_string()?;
-    std::fs::write(&nupackage_toml, content)?;
-    eprintln!("Created nupackage.toml for '{pkg_name}'");
+    let content = manifest.to_nuon_string();
+    std::fs::write(&manifest_path, content)?;
+    eprintln!("Created nupackage.nuon for '{pkg_name}'");
 
     // Create <current-dir-name>/mod.nu if it doesn't exist.
     let module_dir_name = dir
@@ -320,7 +320,7 @@ fn cmd_add(
     // Check if already added
     if manifest.dependencies.modules.contains_key(&pkg_name) {
         return Err(error::QuiverError::Manifest(format!(
-            "dependency '{pkg_name}' already exists in nupackage.toml"
+            "dependency '{pkg_name}' already exists in nupackage.nuon"
         )));
     }
 
@@ -334,10 +334,10 @@ fn cmd_add(
         .dependencies
         .modules
         .insert(pkg_name.clone(), dep_spec);
-    let content = manifest.to_toml_string()?;
-    std::fs::write(dir.join("nupackage.toml"), content)?;
+    let content = manifest.to_nuon_string();
+    std::fs::write(dir.join("nupackage.nuon"), content)?;
 
-    ui::success(format!("Added module '{pkg_name}' to nupackage.toml"));
+    ui::success(format!("Added module '{pkg_name}' to nupackage.nuon"));
 
     // Run install
     installer::install_with_options(dir, false, false, false, false)
@@ -362,7 +362,7 @@ fn cmd_add_plugin(
             .contains_key(&core_plugin_name)
         {
             return Err(error::QuiverError::Manifest(format!(
-                "plugin dependency '{core_plugin_name}' already exists in nupackage.toml"
+                "plugin dependency '{core_plugin_name}' already exists in nupackage.nuon"
             )));
         }
 
@@ -379,10 +379,10 @@ fn cmd_add_plugin(
             .dependencies
             .plugins
             .insert(core_plugin_name.clone(), dep_spec);
-        let content = manifest.to_toml_string()?;
-        std::fs::write(dir.join("nupackage.toml"), content)?;
+        let content = manifest.to_nuon_string();
+        std::fs::write(dir.join("nupackage.nuon"), content)?;
         ui::success(format!(
-            "Added core plugin '{core_plugin_name}' to nupackage.toml"
+            "Added core plugin '{core_plugin_name}' to nupackage.nuon"
         ));
         return installer::install_with_options(dir, false, false, false, true);
     }
@@ -405,7 +405,7 @@ fn cmd_add_plugin(
 
     if manifest.dependencies.plugins.contains_key(&pkg_name) {
         return Err(error::QuiverError::Manifest(format!(
-            "plugin dependency '{pkg_name}' already exists in nupackage.toml"
+            "plugin dependency '{pkg_name}' already exists in nupackage.nuon"
         )));
     }
 
@@ -458,9 +458,9 @@ fn cmd_add_plugin(
         .dependencies
         .plugins
         .insert(pkg_name.clone(), dep_spec);
-    let content = manifest.to_toml_string()?;
-    std::fs::write(dir.join("nupackage.toml"), content)?;
-    ui::success(format!("Added plugin '{pkg_name}' to nupackage.toml"));
+    let content = manifest.to_nuon_string();
+    std::fs::write(dir.join("nupackage.nuon"), content)?;
+    ui::success(format!("Added plugin '{pkg_name}' to nupackage.nuon"));
 
     installer::install_with_options(dir, false, false, false, true)
 }
@@ -622,9 +622,9 @@ fn cmd_remove(dir: &Path, name: String) -> Result<()> {
     // Try removing as a module first
     if manifest.dependencies.modules.remove(&name).is_some() {
         // Write updated manifest
-        let content = manifest.to_toml_string()?;
-        std::fs::write(dir.join("nupackage.toml"), content)?;
-        ui::success(format!("Removed module '{name}' from nupackage.toml"));
+        let content = manifest.to_nuon_string();
+        std::fs::write(dir.join("nupackage.nuon"), content)?;
+        ui::success(format!("Removed module '{name}' from nupackage.nuon"));
 
         // Remove from .nu-env/modules/
         let module_dir = dir.join(".nu-env").join("modules").join(&name);
@@ -648,9 +648,9 @@ fn cmd_remove(dir: &Path, name: String) -> Result<()> {
         }
     } else if let Some(plugin_spec) = manifest.dependencies.plugins.remove(&name) {
         // Removing a plugin dependency
-        let content = manifest.to_toml_string()?;
-        std::fs::write(dir.join("nupackage.toml"), content)?;
-        ui::success(format!("Removed plugin '{name}' from nupackage.toml"));
+        let content = manifest.to_nuon_string();
+        std::fs::write(dir.join("nupackage.nuon"), content)?;
+        ui::success(format!("Removed plugin '{name}' from nupackage.nuon"));
 
         // Remove plugin binary symlink from .nu-env/bin/
         let bin_name = plugin_spec.bin.as_deref().unwrap_or(&name);
@@ -678,7 +678,7 @@ fn cmd_remove(dir: &Path, name: String) -> Result<()> {
         }
     } else {
         return Err(error::QuiverError::Manifest(format!(
-            "dependency '{name}' not found in nupackage.toml"
+            "dependency '{name}' not found in nupackage.nuon"
         )));
     }
 
@@ -906,8 +906,8 @@ fn write_qvx_manifest(
             plugins: HashMap::new(),
         },
     };
-    let content = manifest.to_toml_string()?;
-    let path = env_dir.join("nupackage.toml");
+    let content = manifest.to_nuon_string();
+    let path = env_dir.join("nupackage.nuon");
     let should_write = std::fs::read_to_string(&path)
         .map(|existing| existing != content)
         .unwrap_or(true);
@@ -1094,12 +1094,12 @@ $env.config.hooks.env_change.PWD = (
         let after = ($after | default "")
 
         # Remove previous directory's modules if it was a quiver project
-        if ($before | is-not-empty) and ($before | path join "nupackage.toml" | path exists) {
+        if ($before | is-not-empty) and ($before | path join "nupackage.nuon" | path exists) {
             let old_modules = ($before | path join ".nu-env" "modules")
             $env.NU_LIB_DIRS = ($env.NU_LIB_DIRS | default [] | where {|it| $it != $old_modules })
         }
         # Add new directory's modules if it is a quiver project
-        if ($after | is-not-empty) and ($after | path join "nupackage.toml" | path exists) {
+        if ($after | is-not-empty) and ($after | path join "nupackage.nuon" | path exists) {
             let new_modules = ($after | path join ".nu-env" "modules")
             if ($new_modules | path exists) and ($new_modules not-in ($env.NU_LIB_DIRS | default [])) {
                 $env.NU_LIB_DIRS = ($env.NU_LIB_DIRS | default [] | append $new_modules)
@@ -2230,8 +2230,8 @@ sha256 = "bbb"
         let nested = root.join("examples").join("demo");
         std::fs::create_dir_all(&nested).unwrap();
         std::fs::write(
-            root.join("nupackage.toml"),
-            "[package]\nname = \"demo\"\nversion = \"0.1.0\"\n",
+            root.join("nupackage.nuon"),
+            r#"{ package: { name: "demo", version: "0.1.0" } }"#,
         )
         .unwrap();
         std::fs::create_dir_all(root.join(".nu-env")).unwrap();
@@ -2260,7 +2260,7 @@ sha256 = "bbb"
             .and_then(|n| n.to_str())
             .unwrap()
             .to_string();
-        assert!(project_dir.join("nupackage.toml").exists());
+        assert!(project_dir.join("nupackage.nuon").exists());
         assert!(project_dir.join(&dir_name).join("mod.nu").exists());
         assert!(!project_dir.join("mod.nu").exists());
 
@@ -2293,13 +2293,13 @@ sha256 = "bbb"
 
         cmd_init(&project_dir, None, "0.1.0".to_string(), None, None).unwrap();
 
-        let manifest_text = std::fs::read_to_string(project_dir.join("nupackage.toml")).unwrap();
+        let manifest_text = std::fs::read_to_string(project_dir.join("nupackage.nuon")).unwrap();
         let manifest = Manifest::from_str(&manifest_text).unwrap();
         assert_eq!(
             manifest.package.authors,
             Some(vec!["Alice Example".to_string()])
         );
-        assert!(manifest_text.contains("authors = [\"Alice Example\"]"));
+        assert!(manifest_text.contains("authors: [\"Alice Example\"]"));
 
         let _ = std::fs::remove_dir_all(project_dir);
         let _ = std::fs::remove_dir_all(git_dir);
@@ -2312,10 +2312,10 @@ sha256 = "bbb"
 
         cmd_init(&project_dir, None, "0.1.0".to_string(), None, None).unwrap();
 
-        let manifest_text = std::fs::read_to_string(project_dir.join("nupackage.toml")).unwrap();
+        let manifest_text = std::fs::read_to_string(project_dir.join("nupackage.nuon")).unwrap();
         let manifest = Manifest::from_str(&manifest_text).unwrap();
         assert_eq!(manifest.package.authors, None);
-        assert!(!manifest_text.contains("authors ="));
+        assert!(!manifest_text.contains("authors:"));
 
         let _ = std::fs::remove_dir_all(project_dir);
         let _ = std::fs::remove_dir_all(git_dir);
@@ -2335,7 +2335,7 @@ sha256 = "bbb"
         )
         .unwrap();
 
-        let manifest_text = std::fs::read_to_string(project_dir.join("nupackage.toml")).unwrap();
+        let manifest_text = std::fs::read_to_string(project_dir.join("nupackage.nuon")).unwrap();
         let manifest = Manifest::from_str(&manifest_text).unwrap();
         assert_eq!(manifest.package.name, "custom-module-name");
 
@@ -2372,7 +2372,7 @@ sha256 = "bbb"
         )
         .unwrap();
 
-        let manifest_text = std::fs::read_to_string(project_dir.join("nupackage.toml")).unwrap();
+        let manifest_text = std::fs::read_to_string(project_dir.join("nupackage.nuon")).unwrap();
         let manifest = Manifest::from_str(&manifest_text).unwrap();
         assert_eq!(
             manifest.package.nu_version.as_deref(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -2097,24 +2097,27 @@ mod tests {
         let lock_path = root_dir.join("config.lock");
         std::fs::write(
             &lock_path,
-            r#"version = 1
-
-[[package]]
-name = "nu-utils"
-git = "https://github.com/example/nu-utils"
-tag = "v1.0.0"
-rev = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-sha256 = "aaa"
-
-[[package]]
-name = "nu_plugin_inc"
-kind = "plugin"
-git = "https://github.com/nushell/nu_plugin_inc"
-tag = "v0.91.0"
-rev = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-path = "nu_plugin_inc"
-sha256 = "bbb"
-"#,
+            r#"{
+  version: 1,
+  packages: [
+    {
+      name: "nu-utils",
+      git: "https://github.com/example/nu-utils",
+      tag: "v1.0.0",
+      rev: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      sha256: "aaa",
+    },
+    {
+      name: "nu_plugin_inc",
+      kind: "plugin",
+      git: "https://github.com/nushell/nu_plugin_inc",
+      tag: "v0.91.0",
+      rev: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      path: "nu_plugin_inc",
+      sha256: "bbb",
+    },
+  ],
+}"#,
         )
         .unwrap();
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -98,7 +98,7 @@ impl DependencySpec {
             .expect("validated: one of tag/rev/branch is set")
     }
 
-    fn to_inline_nuon(&self) -> String {
+    pub(crate) fn to_inline_nuon(&self) -> String {
         let mut parts = vec![format!("git: {}", nuon_string(&self.git))];
         if let Some(tag) = &self.tag {
             parts.push(format!("tag: {}", nuon_string(tag)));
@@ -174,7 +174,7 @@ impl PluginDependencySpec {
             .expect("validated: one of tag/rev/branch is set")
     }
 
-    fn to_inline_nuon(&self) -> String {
+    pub(crate) fn to_inline_nuon(&self) -> String {
         let source = self.source.as_deref().unwrap_or("git");
         let mut parts = Vec::new();
         if self.source.is_some() {
@@ -365,7 +365,7 @@ fn write_nuon_list_field(out: &mut String, indent: usize, key: &str, values: &[S
     out.push_str("],\n");
 }
 
-fn nuon_key(key: &str) -> String {
+pub(crate) fn nuon_key(key: &str) -> String {
     let is_bare = key
         .chars()
         .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_');
@@ -376,11 +376,11 @@ fn nuon_key(key: &str) -> String {
     }
 }
 
-fn nuon_string(value: &str) -> String {
+pub(crate) fn nuon_string(value: &str) -> String {
     serde_json::to_string(value).expect("serializing a string cannot fail")
 }
 
-fn nu_value_to_json(value: nu_protocol::Value) -> Result<JsonValue> {
+pub(crate) fn nu_value_to_json(value: nu_protocol::Value) -> Result<JsonValue> {
     match value {
         nu_protocol::Value::Bool { val, .. } => Ok(JsonValue::Bool(val)),
         nu_protocol::Value::Int { val, .. } => Ok(JsonValue::Number(val.into())),

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value as JsonValue};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
@@ -6,7 +7,9 @@ use crate::error::{QuiverError, Result};
 use crate::nu;
 use crate::safety;
 
-/// The top-level `nupackage.toml` manifest.
+pub const MANIFEST_FILE_NAME: &str = "nupackage.nuon";
+
+/// The top-level `nupackage.nuon` manifest.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Manifest {
     pub package: Package,
@@ -14,7 +17,7 @@ pub struct Manifest {
     pub dependencies: DependencyGroups,
 }
 
-/// Dependency groups declared in `nupackage.toml`.
+/// Dependency groups declared in `nupackage.nuon`.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct DependencyGroups {
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
@@ -29,7 +32,7 @@ impl DependencyGroups {
     }
 }
 
-/// The `[package]` section of a manifest.
+/// The `package` section of a manifest.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Package {
     pub name: String,
@@ -44,7 +47,7 @@ pub struct Package {
     pub nu_version: Option<String>,
 }
 
-/// A single module dependency specification from `[dependencies.modules]`.
+/// A single module dependency specification from `dependencies.modules`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DependencySpec {
     pub git: String,
@@ -56,7 +59,7 @@ pub struct DependencySpec {
     pub branch: Option<String>,
 }
 
-/// A single plugin dependency specification from `[dependencies.plugins]`.
+/// A single plugin dependency specification from `dependencies.plugins`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PluginDependencySpec {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -95,18 +98,18 @@ impl DependencySpec {
             .expect("validated: one of tag/rev/branch is set")
     }
 
-    fn to_inline_toml(&self) -> Result<String> {
-        let mut parts = vec![format!("git = {}", toml_scalar(&self.git)?)];
+    fn to_inline_nuon(&self) -> String {
+        let mut parts = vec![format!("git: {}", nuon_string(&self.git))];
         if let Some(tag) = &self.tag {
-            parts.push(format!("tag = {}", toml_scalar(tag)?));
+            parts.push(format!("tag: {}", nuon_string(tag)));
         }
         if let Some(rev) = &self.rev {
-            parts.push(format!("rev = {}", toml_scalar(rev)?));
+            parts.push(format!("rev: {}", nuon_string(rev)));
         }
         if let Some(branch) = &self.branch {
-            parts.push(format!("branch = {}", toml_scalar(branch)?));
+            parts.push(format!("branch: {}", nuon_string(branch)));
         }
-        Ok(parts.join(", "))
+        parts.join(", ")
     }
 }
 
@@ -171,28 +174,28 @@ impl PluginDependencySpec {
             .expect("validated: one of tag/rev/branch is set")
     }
 
-    fn to_inline_toml(&self) -> Result<String> {
+    fn to_inline_nuon(&self) -> String {
         let source = self.source.as_deref().unwrap_or("git");
         let mut parts = Vec::new();
         if self.source.is_some() {
-            parts.push(format!("source = {}", toml_scalar(&source)?));
+            parts.push(format!("source: {}", nuon_string(&source)));
         }
         if source != "nu-core" {
-            parts.push(format!("git = {}", toml_scalar(&self.git)?));
+            parts.push(format!("git: {}", nuon_string(&self.git)));
         }
         if let Some(tag) = &self.tag {
-            parts.push(format!("tag = {}", toml_scalar(tag)?));
+            parts.push(format!("tag: {}", nuon_string(tag)));
         }
         if let Some(rev) = &self.rev {
-            parts.push(format!("rev = {}", toml_scalar(rev)?));
+            parts.push(format!("rev: {}", nuon_string(rev)));
         }
         if let Some(branch) = &self.branch {
-            parts.push(format!("branch = {}", toml_scalar(branch)?));
+            parts.push(format!("branch: {}", nuon_string(branch)));
         }
         if let Some(bin) = &self.bin {
-            parts.push(format!("bin = {}", toml_scalar(bin)?));
+            parts.push(format!("bin: {}", nuon_string(bin)));
         }
-        Ok(parts.join(", "))
+        parts.join(", ")
     }
 }
 
@@ -219,17 +222,17 @@ fn validate_ref_fields(
 }
 
 impl Manifest {
-    /// Find the nearest ancestor directory containing `nupackage.toml`.
+    /// Find the nearest ancestor directory containing `nupackage.nuon`.
     pub fn find_project_dir(start: &Path) -> Option<PathBuf> {
         start
             .ancestors()
-            .find(|dir| dir.join("nupackage.toml").exists())
+            .find(|dir| dir.join(MANIFEST_FILE_NAME).exists())
             .map(Path::to_path_buf)
     }
 
-    /// Read and parse a `nupackage.toml` from the given directory.
+    /// Read and parse a `nupackage.nuon` from the given directory.
     pub fn from_dir(dir: &Path) -> Result<Self> {
-        let path = dir.join("nupackage.toml");
+        let path = dir.join(MANIFEST_FILE_NAME);
         if !path.exists() {
             return Err(QuiverError::NoManifest(dir.to_path_buf()));
         }
@@ -237,9 +240,12 @@ impl Manifest {
         Self::from_str(&content)
     }
 
-    /// Parse a manifest from a TOML string.
+    /// Parse a manifest from a NUON string.
     pub fn from_str(s: &str) -> Result<Self> {
-        let manifest: Manifest = toml::from_str(s)?;
+        let value = nuon::from_nuon(s, None)?;
+        let json = nu_value_to_json(value)?;
+        let manifest: Manifest = serde_json::from_value(json)
+            .map_err(|err| QuiverError::Manifest(format!("invalid manifest schema: {err}")))?;
         manifest.validate()?;
         Ok(manifest)
     }
@@ -277,76 +283,132 @@ impl Manifest {
         Ok(())
     }
 
-    /// Serialize this manifest to a TOML string.
-    pub fn to_toml_string(&self) -> Result<String> {
+    /// Serialize this manifest to a NUON string.
+    pub fn to_nuon_string(&self) -> String {
         let mut out = String::new();
-        out.push_str("[package]\n");
-        write_toml_field(&mut out, "name", &self.package.name)?;
-        write_toml_field(&mut out, "version", &self.package.version)?;
+        out.push_str("{\n");
+        out.push_str("  package: {\n");
+        write_nuon_field(&mut out, 4, "name", &self.package.name);
+        write_nuon_field(&mut out, 4, "version", &self.package.version);
         if let Some(description) = &self.package.description {
-            write_toml_field(&mut out, "description", description)?;
+            write_nuon_field(&mut out, 4, "description", description);
         }
         if let Some(license) = &self.package.license {
-            write_toml_field(&mut out, "license", license)?;
+            write_nuon_field(&mut out, 4, "license", license);
         }
         if let Some(authors) = &self.package.authors {
-            write_toml_field(&mut out, "authors", authors)?;
+            write_nuon_list_field(&mut out, 4, "authors", authors);
         }
         if let Some(nu_version) = &self.package.nu_version {
-            write_toml_field(&mut out, "nu-version", nu_version)?;
+            write_nuon_field(&mut out, 4, "nu-version", nu_version);
+        }
+        out.push_str("  },\n");
+
+        if !self.dependencies.is_empty() {
+            out.push_str("  dependencies: {\n");
         }
 
         if !self.dependencies.modules.is_empty() {
-            out.push_str("\n[dependencies.modules]\n");
+            out.push_str("    modules: {\n");
             let mut modules: Vec<_> = self.dependencies.modules.iter().collect();
             modules.sort_by(|a, b| a.0.cmp(b.0));
             for (name, spec) in modules {
                 out.push_str(&format!(
-                    "{} = {{ {} }}\n",
-                    bare_key_or_quoted(name),
-                    spec.to_inline_toml()?
+                    "      {}: {{ {} }},\n",
+                    nuon_key(name),
+                    spec.to_inline_nuon()
                 ));
             }
+            out.push_str("    },\n");
         }
 
         if !self.dependencies.plugins.is_empty() {
-            out.push_str("\n[dependencies.plugins]\n");
+            out.push_str("    plugins: {\n");
             let mut plugins: Vec<_> = self.dependencies.plugins.iter().collect();
             plugins.sort_by(|a, b| a.0.cmp(b.0));
             for (name, spec) in plugins {
                 out.push_str(&format!(
-                    "{} = {{ {} }}\n",
-                    bare_key_or_quoted(name),
-                    spec.to_inline_toml()?
+                    "      {}: {{ {} }},\n",
+                    nuon_key(name),
+                    spec.to_inline_nuon()
                 ));
             }
+            out.push_str("    },\n");
         }
 
-        Ok(out)
+        if !self.dependencies.is_empty() {
+            out.push_str("  },\n");
+        }
+        out.push_str("}\n");
+        out
     }
 }
 
-fn write_toml_field<T: Serialize>(out: &mut String, key: &str, value: &T) -> Result<()> {
-    out.push_str(key);
-    out.push_str(" = ");
-    out.push_str(&toml_scalar(value)?);
-    out.push('\n');
-    Ok(())
+fn write_nuon_field(out: &mut String, indent: usize, key: &str, value: &str) {
+    out.push_str(&" ".repeat(indent));
+    out.push_str(&nuon_key(key));
+    out.push_str(": ");
+    out.push_str(&nuon_string(value));
+    out.push_str(",\n");
 }
 
-fn toml_scalar<T: Serialize>(value: &T) -> Result<String> {
-    let serialized = toml::Value::try_from(value)?.to_string();
-    Ok(serialized)
+fn write_nuon_list_field(out: &mut String, indent: usize, key: &str, values: &[String]) {
+    out.push_str(&" ".repeat(indent));
+    out.push_str(&nuon_key(key));
+    out.push_str(": [");
+    for (idx, value) in values.iter().enumerate() {
+        if idx > 0 {
+            out.push_str(", ");
+        }
+        out.push_str(&nuon_string(value));
+    }
+    out.push_str("],\n");
 }
 
-fn bare_key_or_quoted(key: &str) -> String {
+fn nuon_key(key: &str) -> String {
     let is_bare = key
         .chars()
         .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_');
     if is_bare {
         key.to_string()
     } else {
-        format!("\"{}\"", key.replace('\"', "\\\""))
+        nuon_string(key)
+    }
+}
+
+fn nuon_string(value: &str) -> String {
+    serde_json::to_string(value).expect("serializing a string cannot fail")
+}
+
+fn nu_value_to_json(value: nu_protocol::Value) -> Result<JsonValue> {
+    match value {
+        nu_protocol::Value::Bool { val, .. } => Ok(JsonValue::Bool(val)),
+        nu_protocol::Value::Int { val, .. } => Ok(JsonValue::Number(val.into())),
+        nu_protocol::Value::Float { val, .. } => serde_json::Number::from_f64(val)
+            .map(JsonValue::Number)
+            .ok_or_else(|| {
+                QuiverError::Manifest("manifest contains a non-finite float".to_string())
+            }),
+        nu_protocol::Value::String { val, .. } | nu_protocol::Value::Glob { val, .. } => {
+            Ok(JsonValue::String(val))
+        }
+        nu_protocol::Value::List { vals, .. } => vals
+            .into_iter()
+            .map(nu_value_to_json)
+            .collect::<Result<Vec<_>>>()
+            .map(JsonValue::Array),
+        nu_protocol::Value::Record { val, .. } => {
+            let mut object = Map::new();
+            for (key, value) in val.into_owned().into_iter() {
+                object.insert(key, nu_value_to_json(value)?);
+            }
+            Ok(JsonValue::Object(object))
+        }
+        nu_protocol::Value::Nothing { .. } => Ok(JsonValue::Null),
+        other => Err(QuiverError::Manifest(format!(
+            "unsupported NUON value in manifest: {}",
+            other.get_type()
+        ))),
     }
 }
 
@@ -368,21 +430,26 @@ mod tests {
 
     #[test]
     fn round_trip_parse_manifest() {
-        let toml = r#"
-[package]
-name = "my-module"
-version = "0.1.0"
-description = "Useful utilities"
-
-[dependencies.modules]
-nu-utils = { git = "https://github.com/someuser/nu-utils", tag = "v1.2.3" }
-nu-http = { git = "https://github.com/someuser/nu-http", branch = "main" }
-
-[dependencies.plugins]
-nu_plugin_inc = { git = "https://github.com/someuser/nu_plugin_inc", tag = "v0.8.0", bin = "nu_plugin_inc" }
+        let nuon = r#"
+{
+  package: {
+    name: "my-module",
+    version: "0.1.0",
+    description: "Useful utilities",
+  },
+  dependencies: {
+    modules: {
+      nu-utils: { git: "https://github.com/someuser/nu-utils", tag: "v1.2.3" },
+      nu-http: { git: "https://github.com/someuser/nu-http", branch: "main" },
+    },
+    plugins: {
+      nu_plugin_inc: { git: "https://github.com/someuser/nu_plugin_inc", tag: "v0.8.0", bin: "nu_plugin_inc" },
+    },
+  },
+}
 "#;
 
-        let manifest = Manifest::from_str(toml).unwrap();
+        let manifest = Manifest::from_str(nuon).unwrap();
         assert_eq!(manifest.package.name, "my-module");
         assert_eq!(manifest.package.version, "0.1.0");
         assert_eq!(manifest.dependencies.modules.len(), 2);
@@ -394,51 +461,45 @@ nu_plugin_inc = { git = "https://github.com/someuser/nu_plugin_inc", tag = "v0.8
 
     #[test]
     fn reject_dep_with_multiple_refs() {
-        let toml = r#"
-[package]
-name = "bad"
-version = "0.1.0"
-
-[dependencies.modules]
-x = { git = "https://example.com/x", tag = "v1", branch = "main" }
+        let nuon = r#"
+{
+  package: { name: "bad", version: "0.1.0" },
+  dependencies: { modules: { x: { git: "https://example.com/x", tag: "v1", branch: "main" } } },
+}
 "#;
 
-        let err = Manifest::from_str(toml).unwrap_err();
+        let err = Manifest::from_str(nuon).unwrap_err();
         assert!(err.to_string().contains("specify only one"));
     }
 
     #[test]
     fn reject_dep_with_no_refs() {
-        let toml = r#"
-[package]
-name = "bad"
-version = "0.1.0"
-
-[dependencies.modules]
-x = { git = "https://example.com/x" }
+        let nuon = r#"
+{
+  package: { name: "bad", version: "0.1.0" },
+  dependencies: { modules: { x: { git: "https://example.com/x" } } },
+}
 "#;
 
-        let err = Manifest::from_str(toml).unwrap_err();
+        let err = Manifest::from_str(nuon).unwrap_err();
         assert!(err.to_string().contains("must specify one"));
     }
 
     #[test]
     fn reject_module_dependency_with_insecure_http_git_source() {
-        let toml = r#"
-[package]
-name = "bad"
-version = "0.1.0"
-
-[dependencies.modules]
-x = { git = "http://example.com/x", tag = "v1.0.0" }
+        let nuon = r#"
+{
+  package: { name: "bad", version: "0.1.0" },
+  dependencies: { modules: { x: { git: "http://example.com/x", tag: "v1.0.0" } } },
+}
 "#;
 
-        let err = Manifest::from_str(toml).unwrap_err();
+        let err = Manifest::from_str(nuon).unwrap_err();
         assert!(err.to_string().contains("insecure HTTP"));
     }
 
     #[test]
-    fn to_toml_string_emits_stable_sorted_dependencies() {
+    fn to_nuon_string_emits_stable_sorted_dependencies() {
         let manifest = Manifest {
             package: Package {
                 name: "my-module".to_string(),
@@ -483,33 +544,33 @@ x = { git = "http://example.com/x", tag = "v1.0.0" }
             },
         };
 
-        let toml = manifest.to_toml_string().unwrap();
+        let nuon = manifest.to_nuon_string();
 
-        assert!(toml.starts_with("[package]\n"));
-        assert!(toml.contains("name = \"my-module\"\n"));
-        assert!(toml.contains("version = \"0.1.0\"\n"));
-        assert!(toml.contains("description = \"Example module\"\n"));
-        assert!(toml.contains("license = \"MIT\"\n"));
-        assert!(toml.contains("authors = [\"Alice\", \"Bob\"]\n"));
-        assert!(toml.contains("nu-version = \"0.91.0\"\n"));
+        assert!(nuon.starts_with("{\n  package: {\n"));
+        assert!(nuon.contains("name: \"my-module\",\n"));
+        assert!(nuon.contains("version: \"0.1.0\",\n"));
+        assert!(nuon.contains("description: \"Example module\",\n"));
+        assert!(nuon.contains("license: \"MIT\",\n"));
+        assert!(nuon.contains("authors: [\"Alice\", \"Bob\"],\n"));
+        assert!(nuon.contains("nu-version: \"0.91.0\",\n"));
 
-        let idx_modules = toml.find("[dependencies.modules]\n").unwrap();
-        let idx_plugins = toml.find("[dependencies.plugins]\n").unwrap();
-        let idx_alpha = toml
-            .find("alpha = { git = \"https://github.com/user/alpha\", branch = \"main\" }")
+        let idx_modules = nuon.find("modules: {\n").unwrap();
+        let idx_plugins = nuon.find("plugins: {\n").unwrap();
+        let idx_alpha = nuon
+            .find("alpha: { git: \"https://github.com/user/alpha\", branch: \"main\" }")
             .unwrap();
-        let idx_zeta = toml
-            .find("zeta = { git = \"https://github.com/user/zeta\", tag = \"v1.0.0\" }")
+        let idx_zeta = nuon
+            .find("zeta: { git: \"https://github.com/user/zeta\", tag: \"v1.0.0\" }")
             .unwrap();
-        let idx_plugin = toml
+        let idx_plugin = nuon
             .find(
-                "nu_plugin_inc = { git = \"https://github.com/user/nu_plugin_inc\", tag = \"v0.9.0\", bin = \"nu_plugin_inc\" }",
+                "nu_plugin_inc: { git: \"https://github.com/user/nu_plugin_inc\", tag: \"v0.9.0\", bin: \"nu_plugin_inc\" }",
             )
             .unwrap();
         assert!(idx_modules < idx_alpha && idx_alpha < idx_zeta);
         assert!(idx_plugins < idx_plugin);
 
-        let parsed = Manifest::from_str(&toml).unwrap();
+        let parsed = Manifest::from_str(&nuon).unwrap();
         assert_eq!(parsed.package.name, "my-module");
         assert_eq!(parsed.dependencies.modules.len(), 2);
         assert_eq!(parsed.dependencies.plugins.len(), 1);
@@ -517,27 +578,18 @@ x = { git = "http://example.com/x", tag = "v1.0.0" }
 
     #[test]
     fn reject_invalid_nu_version_requirement() {
-        let toml = r#"
-[package]
-name = "bad"
-version = "0.1.0"
-nu-version = "not-semver"
-"#;
+        let nuon = r#"{ package: { name: "bad", version: "0.1.0", nu-version: "not-semver" } }"#;
 
-        let err = Manifest::from_str(toml).unwrap_err();
+        let err = Manifest::from_str(nuon).unwrap_err();
         assert!(err.to_string().contains("nu-version"));
     }
 
     #[test]
     fn accepts_semver_range_nu_version_requirement() {
-        let toml = r#"
-[package]
-name = "ok"
-version = "0.1.0"
-nu-version = ">=0.110.0, <0.112.0"
-"#;
+        let nuon =
+            r#"{ package: { name: "ok", version: "0.1.0", nu-version: ">=0.110.0, <0.112.0" } }"#;
 
-        let manifest = Manifest::from_str(toml).unwrap();
+        let manifest = Manifest::from_str(nuon).unwrap();
         assert_eq!(
             manifest.package.nu_version.as_deref(),
             Some(">=0.110.0, <0.112.0")
@@ -546,61 +598,53 @@ nu-version = ">=0.110.0, <0.112.0"
 
     #[test]
     fn reject_plugin_dep_with_no_refs() {
-        let toml = r#"
-[package]
-name = "bad"
-version = "0.1.0"
-
-[dependencies.plugins]
-x = { git = "https://example.com/x", bin = "x" }
+        let nuon = r#"
+{
+  package: { name: "bad", version: "0.1.0" },
+  dependencies: { plugins: { x: { git: "https://example.com/x", bin: "x" } } },
+}
 "#;
 
-        let err = Manifest::from_str(toml).unwrap_err();
+        let err = Manifest::from_str(nuon).unwrap_err();
         assert!(err.to_string().contains("must specify one"));
     }
 
     #[test]
     fn reject_plugin_dep_with_empty_bin() {
-        let toml = r#"
-[package]
-name = "bad"
-version = "0.1.0"
-
-[dependencies.plugins]
-x = { git = "https://example.com/x", tag = "v1.0.0", bin = "   " }
+        let nuon = r#"
+{
+  package: { name: "bad", version: "0.1.0" },
+  dependencies: { plugins: { x: { git: "https://example.com/x", tag: "v1.0.0", bin: "   " } } },
+}
 "#;
 
-        let err = Manifest::from_str(toml).unwrap_err();
+        let err = Manifest::from_str(nuon).unwrap_err();
         assert!(err.to_string().contains("bin cannot be empty"));
     }
 
     #[test]
     fn reject_plugin_dependency_with_insecure_http_git_source() {
-        let toml = r#"
-[package]
-name = "bad"
-version = "0.1.0"
-
-[dependencies.plugins]
-x = { git = "http://example.com/x", tag = "v1.0.0", bin = "x" }
+        let nuon = r#"
+{
+  package: { name: "bad", version: "0.1.0" },
+  dependencies: { plugins: { x: { git: "http://example.com/x", tag: "v1.0.0", bin: "x" } } },
+}
 "#;
 
-        let err = Manifest::from_str(toml).unwrap_err();
+        let err = Manifest::from_str(nuon).unwrap_err();
         assert!(err.to_string().contains("insecure HTTP"));
     }
 
     #[test]
     fn accepts_core_plugin_source_without_git_or_refs() {
-        let toml = r#"
-[package]
-name = "ok"
-version = "0.1.0"
-
-[dependencies.plugins]
-nu_plugin_polars = { source = "nu-core", bin = "nu_plugin_polars" }
+        let nuon = r#"
+{
+  package: { name: "ok", version: "0.1.0" },
+  dependencies: { plugins: { nu_plugin_polars: { source: "nu-core", bin: "nu_plugin_polars" } } },
+}
 "#;
 
-        let manifest = Manifest::from_str(toml).unwrap();
+        let manifest = Manifest::from_str(nuon).unwrap();
         let plugin = manifest
             .dependencies
             .plugins
@@ -615,16 +659,14 @@ nu_plugin_polars = { source = "nu-core", bin = "nu_plugin_polars" }
 
     #[test]
     fn reject_core_plugin_source_with_git_or_refs() {
-        let toml = r#"
-[package]
-name = "bad"
-version = "0.1.0"
-
-[dependencies.plugins]
-nu_plugin_polars = { source = "nu-core", git = "https://example.com/x", tag = "v1.0.0" }
+        let nuon = r#"
+{
+  package: { name: "bad", version: "0.1.0" },
+  dependencies: { plugins: { nu_plugin_polars: { source: "nu-core", git: "https://example.com/x", tag: "v1.0.0" } } },
+}
 "#;
 
-        let err = Manifest::from_str(toml).unwrap_err();
+        let err = Manifest::from_str(nuon).unwrap_err();
         assert!(err.to_string().contains("source = 'nu-core'"));
     }
 
@@ -634,8 +676,8 @@ nu_plugin_polars = { source = "nu-core", git = "https://example.com/x", tag = "v
         let nested = root.join("src").join("commands");
         std::fs::create_dir_all(&nested).unwrap();
         std::fs::write(
-            root.join("nupackage.toml"),
-            "[package]\nname = \"demo\"\nversion = \"0.1.0\"\n",
+            root.join("nupackage.nuon"),
+            r#"{ package: { name: "demo", version: "0.1.0" } }"#,
         )
         .unwrap();
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use crate::error::{QuiverError, Result};
 use crate::nu;
 use crate::safety;
+use crate::ui;
 
 pub const MANIFEST_FILE_NAME: &str = "nupackage.nuon";
 
@@ -234,6 +235,17 @@ impl Manifest {
     pub fn from_dir(dir: &Path) -> Result<Self> {
         let path = dir.join(MANIFEST_FILE_NAME);
         if !path.exists() {
+            if dir.join("nupackage.toml").exists() {
+                ui::warn(
+                    "nupackage.toml detected but quiver now requires nupackage.nuon. Migrate with:",
+                );
+                eprintln!();
+                eprintln!("  open nupackage.toml | to nuon --indent 2 | save -f nupackage.nuon");
+                eprintln!("  rm nupackage.toml");
+                eprintln!("  rm quiver.lock");
+                eprintln!("  qv install");
+                eprintln!();
+            }
             return Err(QuiverError::NoManifest(dir.to_path_buf()));
         }
         let content = std::fs::read_to_string(&path)?;

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -165,7 +165,7 @@ fn resolve_deps(
         );
 
         // Check for transitive dependencies
-        // Export the dep to a temp dir to read its nupackage.toml
+        // Export the dep to a temp dir to read its nupackage.nuon
         let unique = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map(|d| d.as_nanos())

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -308,10 +308,10 @@ impl App {
                 graph_scroll: 0,
                 local_readme: String::new(),
                 local_license: String::new(),
-                status: "Run qv init to create nupackage.toml, or q to quit.".to_string(),
+                status: "Run qv init to create nupackage.nuon, or q to quit.".to_string(),
                 input: String::new(),
                 readme_url: String::new(),
-                readme: "No nupackage.toml was found in this directory or its parents.".to_string(),
+                readme: "No nupackage.nuon was found in this directory or its parents.".to_string(),
                 input_mode: InputMode::Normal,
                 action: None,
                 logs: vec![LogLine::Plain(
@@ -1921,8 +1921,8 @@ fn read_local_readme(dist_info_dir: &Path) -> String {
 }
 
 fn read_local_license(dist_info_dir: &Path) -> String {
-    let nupackage = dist_info_dir.join("nupackage.toml");
-    if let Ok(content) = std::fs::read_to_string(&nupackage) {
+    let manifest_path = dist_info_dir.join("nupackage.nuon");
+    if let Ok(content) = std::fs::read_to_string(&manifest_path) {
         if let Ok(manifest) = crate::manifest::Manifest::from_str(&content) {
             if let Some(license) = manifest.package.license {
                 let trimmed = license.trim();
@@ -2092,12 +2092,8 @@ mod tests {
         assert_eq!(read_local_license(&temp_dir), "MIT");
 
         std::fs::write(
-            temp_dir.join("nupackage.toml"),
-            r#"[package]
-name = "test"
-version = "0.1.0"
-license = "Apache-2.0"
-"#,
+            temp_dir.join("nupackage.nuon"),
+            r#"{ package: { name: "test", version: "0.1.0", license: "Apache-2.0" } }"#,
         )
         .unwrap();
         assert_eq!(read_local_license(&temp_dir), "Apache-2.0");


### PR DESCRIPTION
Per #25, we are switching quiver project manifests, lockfiles, and global config from toml to nuon.

## Changed

- **BREAKING**: The package manifest is now `nupackage.nuon` instead of `nupackage.toml`. The lockfile is also in `nuon` format. Existing projects must migrate:
  ```nushell
  open nupackage.toml | to nuon --indent 2 | save -f nupackage.nuon
  rm nupackage.toml
  rm quiver.lock
  qv install
  ```
- **BREAKING**: The global Quiver config is now `config.nuon`. Navigate to your global quiver config dir and run the following to migrate:
  ```nushell
    open config.toml | to nuon --indent 2 | save -f config.nuon
    rm config.toml
    rm quiver.lock
    qv install -g
  ```
- Quiver will warn users with migration instructions when a legacy `nupackage.toml` or `config.toml` is detected.

This closes #25 