### PR TITLE
feat: parallelize dependency fetching and installs with rayon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crossterm"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1954,6 +1979,7 @@ dependencies = [
  "nu-protocol",
  "nuon",
  "ratatui",
+ "rayon",
  "semver",
  "serde",
  "serde_json",
@@ -2001,6 +2027,26 @@ dependencies = [
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ ratatui = "0.29"
 crossterm = "0.29"
 syntect = "5.2"
 tui-scrollview = "0.5"
+rayon = "1"
 
 [dependencies.nu-protocol]
 version = "0.112.2"

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,6 +1,6 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use git2::{FetchOptions, Progress, RemoteCallbacks, Repository, build::RepoBuilder};
 use indicatif::ProgressBar;
@@ -11,6 +11,21 @@ use crate::error::{QuiverError, Result};
 use crate::ui;
 
 static FETCHED_THIS_RUN: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+static URL_LOCKS: OnceLock<Mutex<HashMap<String, Arc<Mutex<()>>>>> = OnceLock::new();
+
+fn url_locks() -> &'static Mutex<HashMap<String, Arc<Mutex<()>>>> {
+    URL_LOCKS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Acquire a per-URL serialization lock so concurrent callers don't race on the
+/// same cached repo. Returns an owned guard that releases on drop.
+fn lock_for_url(url: &str) -> Arc<Mutex<()>> {
+    let key = normalize_git_url(url);
+    let mut map = url_locks().lock().expect("url lock map poisoned");
+    map.entry(key)
+        .or_insert_with(|| Arc::new(Mutex::new(())))
+        .clone()
+}
 
 /// Returns the global install directory for git repos:
 /// `~/.local/share/quiver/installs/git/` on macOS/Linux.
@@ -72,6 +87,11 @@ pub fn clone_or_fetch(url: &str) -> Result<PathBuf> {
 
     let repo_dir = cache.join(url_to_dirname(url));
     let repo_label = repo_name_from_url(url).unwrap_or_else(|| url.to_string());
+
+    // Serialize concurrent callers for the same URL — git2 operations against a
+    // shared on-disk repo are not safe to overlap.
+    let url_lock = lock_for_url(url);
+    let _url_guard = url_lock.lock().expect("url lock poisoned");
 
     if repo_dir.exists() {
         if was_fetched_this_run(url) {

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -2,9 +2,11 @@ use std::collections::{HashMap, HashSet};
 use std::io::{self, Read, Write};
 use std::path::{Component, Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, OnceLock};
 
 use flate2::read::GzDecoder;
+use rayon::prelude::*;
 use semver::{Version, VersionReq};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
@@ -33,6 +35,8 @@ const QUIVER_SKIP_NU_INSTALL_ENV: &str = "QUIVER_SKIP_NU_INSTALL";
 const QUIVER_NU_BIN_ENV: &str = "QUIVER_NU_BIN";
 
 static GITHUB_RELEASE_CACHE: OnceLock<Mutex<HashMap<String, Vec<GitHubRelease>>>> = OnceLock::new();
+static INTERACTIVE_PROMPT_LOCK: Mutex<()> = Mutex::new(());
+static STAGING_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Default)]
 struct NupmMetadataHints {
@@ -326,7 +330,6 @@ fn install_resolved_global(
     } else {
         None
     };
-    let mut plugin_targets = Vec::new();
     let changed_module_count = modules
         .iter()
         .filter(|dep| !resolved_module_matches_existing_lock(dep, existing_lockfile.as_ref()))
@@ -336,143 +339,37 @@ fn install_resolved_global(
         .filter(|plugin| !resolved_plugin_matches_existing_lock(plugin, existing_lockfile.as_ref()))
         .count();
 
-    for dep in modules {
-        safety::validate_dependency_name(&dep.name, "module dependency")?;
-        let existing_locked_module = existing_lockfile
-            .as_ref()
-            .and_then(|lock| lock.find_package(&dep.name, LockedPackageKind::Module));
-        let module_is_current =
-            installed_global_module_matches_lock(dep, modules_dir, existing_locked_module)?;
-        if !module_is_current {
-            ui::info(format!(
-                "{} module {}@{}",
-                ui::keyword("Installing"),
-                dep.name,
-                &dep.rev[..12.min(dep.rev.len())]
-            ));
-            install_dep(dep, modules_dir, install_mode)?;
-        }
-
-        let dest = modules_dir.join(&dep.name);
-        let sha256 = if module_is_current {
-            existing_locked_module
-                .map(|locked| locked.sha256.clone())
-                .ok_or_else(|| {
-                    crate::error::QuiverError::Other(format!(
-                        "missing existing lockfile entry for module '{}'",
-                        dep.name
-                    ))
-                })?
-        } else {
-            resolver::compute_checksum(&dest)?
-        };
-        if frozen {
-            verify_frozen_checksum(
+    let module_locks: Vec<LockedPackage> = modules
+        .par_iter()
+        .map(|dep| {
+            install_global_module_and_lock(
+                dep,
+                modules_dir,
+                install_mode,
+                frozen,
                 frozen_lockfile,
-                &dep.name,
-                LockedPackageKind::Module,
-                &sha256,
-            )?;
-        }
+                existing_lockfile.as_ref(),
+            )
+        })
+        .collect::<Result<Vec<_>>>()?;
+    locked_packages.extend(module_locks);
 
-        locked_packages.push(LockedPackage {
-            name: dep.name.clone(),
-            kind: LockedPackageKind::Module,
-            git: dep.git.clone(),
-            tag: dep.tag.clone(),
-            rev: dep.rev.clone(),
-            path: None,
-            sha256,
-            asset_sha256: None,
-            asset_url: None,
-        });
-    }
-
-    for plugin in plugins {
-        safety::validate_dependency_name(&plugin.name, "plugin dependency")?;
-        if let Some(bin) = plugin.bin.as_deref() {
-            safety::validate_binary_name(bin, "plugin dependency bin")?;
-        }
-        let frozen_locked_plugin = frozen_lockfile
-            .and_then(|lock| lock.find_package(&plugin.name, LockedPackageKind::Plugin));
-        let plugin_install = install_plugin(plugin, None, security_policy, frozen_locked_plugin)?;
-        let installed_bin = plugin_install.installed_bin;
-        let bin_name = plugin_install.bin_name;
-        let version_dir = plugin_install.version_dir;
-        if !resolved_plugin_matches_existing_lock(plugin, existing_lockfile.as_ref()) {
-            ui::info(format!(
-                "{} plugin {}@{}",
-                ui::keyword("Installing"),
-                plugin.name,
-                plugin_install_display_ref(plugin, &version_dir)
-            ));
-        }
-        let sha256 = resolver::compute_checksum(&version_dir)?;
-        if frozen {
-            verify_frozen_checksum(
+    let plugin_results: Vec<(LockedPackage, (String, PathBuf))> = plugins
+        .par_iter()
+        .map(|plugin| {
+            install_global_plugin_and_lock(
+                plugin,
+                security_policy,
+                frozen,
                 frozen_lockfile,
-                &plugin.name,
-                LockedPackageKind::Plugin,
-                &sha256,
-            )?;
-        }
-        if frozen
-            && let Some(expected_asset_sha) =
-                frozen_locked_plugin.and_then(|locked| locked.asset_sha256.as_deref())
-        {
-            let actual_asset_sha = plugin_install.asset_metadata.asset_sha256.as_deref().ok_or_else(|| {
-                crate::error::QuiverError::Lockfile(format!(
-                    "frozen install requires downloaded asset_sha256 for plugin '{}' but no verified release asset digest was recorded",
-                    plugin.name
-                ))
-            })?;
-            if expected_asset_sha != actual_asset_sha {
-                return Err(crate::error::QuiverError::Lockfile(format!(
-                    "frozen install asset checksum mismatch for plugin '{}': expected {}, got {}",
-                    plugin.name, expected_asset_sha, actual_asset_sha
-                )));
-            }
-        }
-
-        let existing_metadata = existing_lockfile
-            .as_ref()
-            .and_then(|lock| lock.find_package(&plugin.name, LockedPackageKind::Plugin));
-        let asset_sha256 = plugin_install
-            .asset_metadata
-            .asset_sha256
-            .or_else(|| existing_metadata.and_then(|pkg| pkg.asset_sha256.clone()));
-        let asset_url = plugin_install
-            .asset_metadata
-            .asset_url
-            .or_else(|| existing_metadata.and_then(|pkg| pkg.asset_url.clone()));
-
-        let locked_tag = if plugin.git == "nu-core" {
-            None
-        } else {
-            plugin.tag.clone()
-        };
-        let locked_rev = if plugin.git == "nu-core" {
-            version_dir
-                .file_name()
-                .and_then(|name| name.to_str())
-                .unwrap_or("nu-core")
-                .to_string()
-        } else {
-            plugin.rev.clone()
-        };
-
-        plugin_targets.push((plugin_registry_name(&bin_name), installed_bin));
-        locked_packages.push(LockedPackage {
-            name: plugin.name.clone(),
-            kind: LockedPackageKind::Plugin,
-            git: plugin.git.clone(),
-            tag: locked_tag,
-            rev: locked_rev,
-            path: Some(bin_name),
-            sha256,
-            asset_sha256,
-            asset_url,
-        });
+                existing_lockfile.as_ref(),
+            )
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let mut plugin_targets = Vec::with_capacity(plugin_results.len());
+    for (locked, target) in plugin_results {
+        locked_packages.push(locked);
+        plugin_targets.push(target);
     }
 
     locked_packages.sort_by(|a, b| a.kind.cmp(&b.kind).then(a.name.cmp(&b.name)));
@@ -725,129 +622,27 @@ fn install_resolved(
         None
     };
 
-    for dep in modules {
-        safety::validate_dependency_name(&dep.name, "module dependency")?;
-        ui::info(format!(
-            "{} module {}@{}",
-            ui::keyword("Installing"),
-            dep.name,
-            &dep.rev[..12.min(dep.rev.len())]
-        ));
-        install_dep(dep, modules_dir, install_mode)?;
+    let module_locks: Vec<LockedPackage> = modules
+        .par_iter()
+        .map(|dep| install_module_and_lock(dep, modules_dir, install_mode, frozen, frozen_lockfile))
+        .collect::<Result<Vec<_>>>()?;
+    locked_packages.extend(module_locks);
 
-        let dest = modules_dir.join(&dep.name);
-        let sha256 = resolver::compute_checksum(&dest)?;
-        if frozen {
-            verify_frozen_checksum(
+    let plugin_locks: Vec<LockedPackage> = plugins
+        .par_iter()
+        .map(|plugin| {
+            install_plugin_and_lock(
+                plugin,
+                bin_dir,
+                nu_version_req,
+                security_policy,
+                frozen,
                 frozen_lockfile,
-                &dep.name,
-                LockedPackageKind::Module,
-                &sha256,
-            )?;
-        }
-
-        locked_packages.push(LockedPackage {
-            name: dep.name.clone(),
-            kind: LockedPackageKind::Module,
-            git: dep.git.clone(),
-            tag: dep.tag.clone(),
-            rev: dep.rev.clone(),
-            path: None,
-            sha256,
-            asset_sha256: None,
-            asset_url: None,
-        });
-    }
-
-    for plugin in plugins {
-        safety::validate_dependency_name(&plugin.name, "plugin dependency")?;
-        if let Some(bin) = plugin.bin.as_deref() {
-            safety::validate_binary_name(bin, "plugin dependency bin")?;
-        }
-        let frozen_locked_plugin = frozen_lockfile
-            .and_then(|lock| lock.find_package(&plugin.name, LockedPackageKind::Plugin));
-        let plugin_install = install_plugin(
-            plugin,
-            nu_version_req,
-            security_policy,
-            frozen_locked_plugin,
-        )?;
-        let installed_bin = plugin_install.installed_bin;
-        let bin_name = plugin_install.bin_name;
-        let version_dir = plugin_install.version_dir;
-        ui::info(format!(
-            "{} plugin {}@{}",
-            ui::keyword("Installing"),
-            plugin.name,
-            plugin_install_display_ref(plugin, &version_dir)
-        ));
-        link_plugin_into_env(&installed_bin, bin_dir, &bin_name)?;
-        let sha256 = resolver::compute_checksum(&version_dir)?;
-        if frozen {
-            verify_frozen_checksum(
-                frozen_lockfile,
-                &plugin.name,
-                LockedPackageKind::Plugin,
-                &sha256,
-            )?;
-        }
-        if frozen
-            && let Some(expected_asset_sha) =
-                frozen_locked_plugin.and_then(|locked| locked.asset_sha256.as_deref())
-        {
-            let actual_asset_sha = plugin_install.asset_metadata.asset_sha256.as_deref().ok_or_else(|| {
-                crate::error::QuiverError::Lockfile(format!(
-                    "frozen install requires downloaded asset_sha256 for plugin '{}' but no verified release asset digest was recorded",
-                    plugin.name
-                ))
-            })?;
-            if expected_asset_sha != actual_asset_sha {
-                return Err(crate::error::QuiverError::Lockfile(format!(
-                    "frozen install asset checksum mismatch for plugin '{}': expected {}, got {}",
-                    plugin.name, expected_asset_sha, actual_asset_sha
-                )));
-            }
-        }
-
-        let existing_metadata = existing_lockfile
-            .as_ref()
-            .and_then(|lock| lock.find_package(&plugin.name, LockedPackageKind::Plugin));
-        let asset_sha256 = plugin_install
-            .asset_metadata
-            .asset_sha256
-            .or_else(|| existing_metadata.and_then(|pkg| pkg.asset_sha256.clone()));
-        let asset_url = plugin_install
-            .asset_metadata
-            .asset_url
-            .or_else(|| existing_metadata.and_then(|pkg| pkg.asset_url.clone()));
-
-        let locked_tag = if plugin.git == "nu-core" {
-            None
-        } else {
-            plugin.tag.clone()
-        };
-        let locked_rev = if plugin.git == "nu-core" {
-            version_dir
-                .file_name()
-                .and_then(|name| name.to_str())
-                .unwrap_or("nu-core")
-                .to_string()
-        } else {
-            plugin.rev.clone()
-        };
-
-        locked_packages.push(LockedPackage {
-            name: plugin.name.clone(),
-            kind: LockedPackageKind::Plugin,
-            git: plugin.git.clone(),
-            tag: locked_tag,
-            rev: locked_rev,
-            path: Some(bin_name),
-            sha256,
-            asset_sha256,
-            asset_url,
-        });
-    }
+                existing_lockfile.as_ref(),
+            )
+        })
+        .collect::<Result<Vec<_>>>()?;
+    locked_packages.extend(plugin_locks);
 
     locked_packages.sort_by(|a, b| a.kind.cmp(&b.kind).then(a.name.cmp(&b.name)));
 
@@ -2230,6 +2025,295 @@ struct PluginInstallResult {
     asset_metadata: DownloadVerificationMetadata,
 }
 
+fn install_global_module_and_lock(
+    dep: &ResolvedDep,
+    modules_dir: &Path,
+    install_mode: InstallMode,
+    frozen: bool,
+    frozen_lockfile: Option<&Lockfile>,
+    existing_lockfile: Option<&Lockfile>,
+) -> Result<LockedPackage> {
+    safety::validate_dependency_name(&dep.name, "module dependency")?;
+    let existing_locked_module =
+        existing_lockfile.and_then(|lock| lock.find_package(&dep.name, LockedPackageKind::Module));
+    let module_is_current =
+        installed_global_module_matches_lock(dep, modules_dir, existing_locked_module)?;
+    if !module_is_current {
+        ui::info(format!(
+            "{} module {}@{}",
+            ui::keyword("Installing"),
+            dep.name,
+            &dep.rev[..12.min(dep.rev.len())]
+        ));
+        install_dep(dep, modules_dir, install_mode)?;
+    }
+
+    let dest = modules_dir.join(&dep.name);
+    let sha256 = if module_is_current {
+        existing_locked_module
+            .map(|locked| locked.sha256.clone())
+            .ok_or_else(|| {
+                crate::error::QuiverError::Other(format!(
+                    "missing existing lockfile entry for module '{}'",
+                    dep.name
+                ))
+            })?
+    } else {
+        resolver::compute_checksum(&dest)?
+    };
+    if frozen {
+        verify_frozen_checksum(
+            frozen_lockfile,
+            &dep.name,
+            LockedPackageKind::Module,
+            &sha256,
+        )?;
+    }
+
+    Ok(LockedPackage {
+        name: dep.name.clone(),
+        kind: LockedPackageKind::Module,
+        git: dep.git.clone(),
+        tag: dep.tag.clone(),
+        rev: dep.rev.clone(),
+        path: None,
+        sha256,
+        asset_sha256: None,
+        asset_url: None,
+    })
+}
+
+fn install_global_plugin_and_lock(
+    plugin: &ResolvedPlugin,
+    security_policy: SecurityPolicy,
+    frozen: bool,
+    frozen_lockfile: Option<&Lockfile>,
+    existing_lockfile: Option<&Lockfile>,
+) -> Result<(LockedPackage, (String, PathBuf))> {
+    safety::validate_dependency_name(&plugin.name, "plugin dependency")?;
+    if let Some(bin) = plugin.bin.as_deref() {
+        safety::validate_binary_name(bin, "plugin dependency bin")?;
+    }
+    let frozen_locked_plugin =
+        frozen_lockfile.and_then(|lock| lock.find_package(&plugin.name, LockedPackageKind::Plugin));
+    let plugin_install = install_plugin(plugin, None, security_policy, frozen_locked_plugin)?;
+    let installed_bin = plugin_install.installed_bin;
+    let bin_name = plugin_install.bin_name;
+    let version_dir = plugin_install.version_dir;
+    if !resolved_plugin_matches_existing_lock(plugin, existing_lockfile) {
+        ui::info(format!(
+            "{} plugin {}@{}",
+            ui::keyword("Installing"),
+            plugin.name,
+            plugin_install_display_ref(plugin, &version_dir)
+        ));
+    }
+    let sha256 = resolver::compute_checksum(&version_dir)?;
+    if frozen {
+        verify_frozen_checksum(
+            frozen_lockfile,
+            &plugin.name,
+            LockedPackageKind::Plugin,
+            &sha256,
+        )?;
+    }
+    if frozen
+        && let Some(expected_asset_sha) =
+            frozen_locked_plugin.and_then(|locked| locked.asset_sha256.as_deref())
+    {
+        let actual_asset_sha = plugin_install.asset_metadata.asset_sha256.as_deref().ok_or_else(|| {
+            crate::error::QuiverError::Lockfile(format!(
+                "frozen install requires downloaded asset_sha256 for plugin '{}' but no verified release asset digest was recorded",
+                plugin.name
+            ))
+        })?;
+        if expected_asset_sha != actual_asset_sha {
+            return Err(crate::error::QuiverError::Lockfile(format!(
+                "frozen install asset checksum mismatch for plugin '{}': expected {}, got {}",
+                plugin.name, expected_asset_sha, actual_asset_sha
+            )));
+        }
+    }
+
+    let existing_metadata = existing_lockfile
+        .and_then(|lock| lock.find_package(&plugin.name, LockedPackageKind::Plugin));
+    let asset_sha256 = plugin_install
+        .asset_metadata
+        .asset_sha256
+        .or_else(|| existing_metadata.and_then(|pkg| pkg.asset_sha256.clone()));
+    let asset_url = plugin_install
+        .asset_metadata
+        .asset_url
+        .or_else(|| existing_metadata.and_then(|pkg| pkg.asset_url.clone()));
+
+    let locked_tag = if plugin.git == "nu-core" {
+        None
+    } else {
+        plugin.tag.clone()
+    };
+    let locked_rev = if plugin.git == "nu-core" {
+        version_dir
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("nu-core")
+            .to_string()
+    } else {
+        plugin.rev.clone()
+    };
+
+    let target = (plugin_registry_name(&bin_name), installed_bin);
+    let locked = LockedPackage {
+        name: plugin.name.clone(),
+        kind: LockedPackageKind::Plugin,
+        git: plugin.git.clone(),
+        tag: locked_tag,
+        rev: locked_rev,
+        path: Some(bin_name),
+        sha256,
+        asset_sha256,
+        asset_url,
+    };
+    Ok((locked, target))
+}
+
+fn install_module_and_lock(
+    dep: &ResolvedDep,
+    modules_dir: &Path,
+    install_mode: InstallMode,
+    frozen: bool,
+    frozen_lockfile: Option<&Lockfile>,
+) -> Result<LockedPackage> {
+    safety::validate_dependency_name(&dep.name, "module dependency")?;
+    ui::info(format!(
+        "{} module {}@{}",
+        ui::keyword("Installing"),
+        dep.name,
+        &dep.rev[..12.min(dep.rev.len())]
+    ));
+    install_dep(dep, modules_dir, install_mode)?;
+
+    let dest = modules_dir.join(&dep.name);
+    let sha256 = resolver::compute_checksum(&dest)?;
+    if frozen {
+        verify_frozen_checksum(
+            frozen_lockfile,
+            &dep.name,
+            LockedPackageKind::Module,
+            &sha256,
+        )?;
+    }
+
+    Ok(LockedPackage {
+        name: dep.name.clone(),
+        kind: LockedPackageKind::Module,
+        git: dep.git.clone(),
+        tag: dep.tag.clone(),
+        rev: dep.rev.clone(),
+        path: None,
+        sha256,
+        asset_sha256: None,
+        asset_url: None,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn install_plugin_and_lock(
+    plugin: &ResolvedPlugin,
+    bin_dir: &Path,
+    nu_version_req: Option<&str>,
+    security_policy: SecurityPolicy,
+    frozen: bool,
+    frozen_lockfile: Option<&Lockfile>,
+    existing_lockfile: Option<&Lockfile>,
+) -> Result<LockedPackage> {
+    safety::validate_dependency_name(&plugin.name, "plugin dependency")?;
+    if let Some(bin) = plugin.bin.as_deref() {
+        safety::validate_binary_name(bin, "plugin dependency bin")?;
+    }
+    let frozen_locked_plugin =
+        frozen_lockfile.and_then(|lock| lock.find_package(&plugin.name, LockedPackageKind::Plugin));
+    let plugin_install = install_plugin(
+        plugin,
+        nu_version_req,
+        security_policy,
+        frozen_locked_plugin,
+    )?;
+    let installed_bin = plugin_install.installed_bin;
+    let bin_name = plugin_install.bin_name;
+    let version_dir = plugin_install.version_dir;
+    ui::info(format!(
+        "{} plugin {}@{}",
+        ui::keyword("Installing"),
+        plugin.name,
+        plugin_install_display_ref(plugin, &version_dir)
+    ));
+    link_plugin_into_env(&installed_bin, bin_dir, &bin_name)?;
+    let sha256 = resolver::compute_checksum(&version_dir)?;
+    if frozen {
+        verify_frozen_checksum(
+            frozen_lockfile,
+            &plugin.name,
+            LockedPackageKind::Plugin,
+            &sha256,
+        )?;
+    }
+    if frozen
+        && let Some(expected_asset_sha) =
+            frozen_locked_plugin.and_then(|locked| locked.asset_sha256.as_deref())
+    {
+        let actual_asset_sha = plugin_install.asset_metadata.asset_sha256.as_deref().ok_or_else(|| {
+            crate::error::QuiverError::Lockfile(format!(
+                "frozen install requires downloaded asset_sha256 for plugin '{}' but no verified release asset digest was recorded",
+                plugin.name
+            ))
+        })?;
+        if expected_asset_sha != actual_asset_sha {
+            return Err(crate::error::QuiverError::Lockfile(format!(
+                "frozen install asset checksum mismatch for plugin '{}': expected {}, got {}",
+                plugin.name, expected_asset_sha, actual_asset_sha
+            )));
+        }
+    }
+
+    let existing_metadata = existing_lockfile
+        .and_then(|lock| lock.find_package(&plugin.name, LockedPackageKind::Plugin));
+    let asset_sha256 = plugin_install
+        .asset_metadata
+        .asset_sha256
+        .or_else(|| existing_metadata.and_then(|pkg| pkg.asset_sha256.clone()));
+    let asset_url = plugin_install
+        .asset_metadata
+        .asset_url
+        .or_else(|| existing_metadata.and_then(|pkg| pkg.asset_url.clone()));
+
+    let locked_tag = if plugin.git == "nu-core" {
+        None
+    } else {
+        plugin.tag.clone()
+    };
+    let locked_rev = if plugin.git == "nu-core" {
+        version_dir
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("nu-core")
+            .to_string()
+    } else {
+        plugin.rev.clone()
+    };
+
+    Ok(LockedPackage {
+        name: plugin.name.clone(),
+        kind: LockedPackageKind::Plugin,
+        git: plugin.git.clone(),
+        tag: locked_tag,
+        rev: locked_rev,
+        path: Some(bin_name),
+        sha256,
+        asset_sha256,
+        asset_url,
+    })
+}
+
 fn install_plugin(
     plugin: &ResolvedPlugin,
     nu_version_req: Option<&str>,
@@ -2571,6 +2655,10 @@ fn prompt_for_cargo_fallback_approval(
     plugin: &ResolvedPlugin,
     release_error: &crate::error::QuiverError,
 ) -> Result<bool> {
+    // Serialize so concurrent plugin installs don't interleave their stdin prompts.
+    let _guard = INTERACTIVE_PROMPT_LOCK
+        .lock()
+        .expect("interactive prompt lock poisoned");
     eprintln!("  Release install failed with: {}", release_error);
 
     loop {
@@ -3026,7 +3114,11 @@ fn install_dep(dep: &ResolvedDep, modules_dir: &Path, install_mode: InstallMode)
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let staging = modules_dir.join(format!(".quiver-staging-{}-{unique}", std::process::id()));
+    let counter = STAGING_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let staging = modules_dir.join(format!(
+        ".quiver-staging-{}-{unique}-{counter}",
+        std::process::id()
+    ));
     if staging.exists() {
         std::fs::remove_dir_all(&staging)?;
     }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use rayon::prelude::*;
 use semver::VersionReq;
 
 use crate::checksum;
@@ -12,6 +14,8 @@ use crate::manifest::{DependencySpec, Manifest, PluginDependencySpec};
 use crate::nu;
 use crate::safety;
 use crate::ui;
+
+static RESOLVE_TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// A fully resolved dependency.
 #[derive(Debug, Clone)]
@@ -70,43 +74,44 @@ pub fn resolve_modules_from_lock(locked: &[LockedPackage]) -> Vec<ResolvedDep> {
 pub fn resolve_plugins_from_deps(
     deps: &HashMap<String, PluginDependencySpec>,
 ) -> Result<Vec<ResolvedPlugin>> {
-    let mut resolved = Vec::new();
+    let entries: Vec<(&String, &PluginDependencySpec)> = deps.iter().collect();
+    let mut resolved: Vec<ResolvedPlugin> = entries
+        .par_iter()
+        .map(|(name, spec)| {
+            safety::validate_dependency_name(name, "plugin dependency")?;
+            if let Some(bin) = spec.bin.as_deref() {
+                safety::validate_binary_name(bin, "plugin dependency bin")?;
+            }
+            let source = spec.source.as_deref().unwrap_or("git");
+            if source == "nu-core" {
+                return Ok(ResolvedPlugin {
+                    name: (*name).clone(),
+                    git: "nu-core".to_string(),
+                    tag: None,
+                    rev: "nu-core".to_string(),
+                    bin: spec.bin.clone(),
+                });
+            }
 
-    for (name, spec) in deps {
-        safety::validate_dependency_name(name, "plugin dependency")?;
-        if let Some(bin) = spec.bin.as_deref() {
-            safety::validate_binary_name(bin, "plugin dependency bin")?;
-        }
-        let source = spec.source.as_deref().unwrap_or("git");
-        if source == "nu-core" {
-            resolved.push(ResolvedPlugin {
-                name: name.clone(),
-                git: "nu-core".to_string(),
-                tag: None,
-                rev: "nu-core".to_string(),
+            ui::info(format!(
+                "{} plugin {} from {}",
+                ui::keyword("Fetching"),
+                name,
+                spec.git
+            ));
+            let repo_path = git::clone_or_fetch(&spec.git)?;
+            let kind = RefKind::from_spec(&spec.tag, &spec.rev, &spec.branch);
+            let rev = git::resolve_ref(&repo_path, spec.ref_spec(), kind)?;
+
+            Ok(ResolvedPlugin {
+                name: (*name).clone(),
+                git: spec.git.clone(),
+                tag: spec.tag.clone(),
+                rev,
                 bin: spec.bin.clone(),
-            });
-            continue;
-        }
-
-        ui::info(format!(
-            "{} plugin {} from {}",
-            ui::keyword("Fetching"),
-            name,
-            spec.git
-        ));
-        let repo_path = git::clone_or_fetch(&spec.git)?;
-        let kind = RefKind::from_spec(&spec.tag, &spec.rev, &spec.branch);
-        let rev = git::resolve_ref(&repo_path, spec.ref_spec(), kind)?;
-
-        resolved.push(ResolvedPlugin {
-            name: name.clone(),
-            git: spec.git.clone(),
-            tag: spec.tag.clone(),
-            rev,
-            bin: spec.bin.clone(),
-        });
-    }
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
 
     resolved.sort_by(|a, b| a.name.cmp(&b.name));
     Ok(resolved)
@@ -134,15 +139,27 @@ fn resolve_deps(
     resolved: &mut HashMap<String, ResolvedDep>,
     root_nu_req: Option<&VersionReq>,
 ) -> Result<()> {
+    // Pre-fetch every sibling repo at this layer in parallel. Each
+    // `clone_or_fetch` is self-locking per URL, so concurrent siblings with
+    // distinct URLs make progress in parallel and same-URL ones serialize
+    // safely. The serial walk below then hits a warm cache.
+    let entries: Vec<(&String, &DependencySpec)> = deps.iter().collect();
+    entries
+        .par_iter()
+        .map(|(name, spec)| {
+            safety::validate_dependency_name(name, "module dependency")?;
+            ui::info(format!(
+                "{} module {} from {}",
+                ui::keyword("Fetching"),
+                name,
+                spec.git
+            ));
+            git::clone_or_fetch(&spec.git)?;
+            Ok::<(), QuiverError>(())
+        })
+        .collect::<Result<Vec<_>>>()?;
+
     for (name, spec) in deps {
-        safety::validate_dependency_name(name, "module dependency")?;
-        // Clone or fetch the repo
-        ui::info(format!(
-            "{} module {} from {}",
-            ui::keyword("Fetching"),
-            name,
-            spec.git
-        ));
         let repo_path = git::clone_or_fetch(&spec.git)?;
 
         // Resolve the ref to a commit SHA
@@ -178,11 +195,12 @@ fn resolve_deps(
             .duration_since(UNIX_EPOCH)
             .map(|d| d.as_nanos())
             .unwrap_or(0);
+        let counter = RESOLVE_TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
         let tmp = std::env::temp_dir().join("quiver_resolve").join(format!(
             "dep-{}-{}-{}",
             std::process::id(),
             unique,
-            resolved.len()
+            counter
         ));
         git::export_to(&repo_path, &rev, &tmp)?;
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,4 +1,4 @@
-use std::cell::RefCell;
+use std::sync::{Mutex, OnceLock};
 
 use console::style;
 use indicatif::{ProgressBar, ProgressStyle};
@@ -17,36 +17,48 @@ pub struct CapturedLog {
     pub message: String,
 }
 
-type LogCapture = Box<dyn FnMut(CapturedLog)>;
+type LogCapture = Box<dyn FnMut(CapturedLog) + Send>;
 
-thread_local! {
-    static LOG_CAPTURE: RefCell<Option<LogCapture>> = const { RefCell::new(None) };
+// Global so parallel workers route through the same capture as the main thread.
+// Emit callbacks must not recursively call into ui::*; doing so will deadlock.
+static LOG_CAPTURE: OnceLock<Mutex<Option<LogCapture>>> = OnceLock::new();
+
+fn log_capture() -> &'static Mutex<Option<LogCapture>> {
+    LOG_CAPTURE.get_or_init(|| Mutex::new(None))
 }
 
-pub fn capture_logs_stream<T>(emit: impl FnMut(CapturedLog) + 'static, f: impl FnOnce() -> T) -> T {
-    LOG_CAPTURE.with(|capture| {
-        let previous = capture.replace(Some(Box::new(emit)));
-        let result = f();
-        let _ = capture.replace(previous);
-        result
-    })
+pub fn capture_logs_stream<T>(
+    emit: impl FnMut(CapturedLog) + Send + 'static,
+    f: impl FnOnce() -> T,
+) -> T {
+    let previous = {
+        let mut guard = log_capture().lock().expect("log capture lock poisoned");
+        guard.replace(Box::new(emit))
+    };
+    let result = f();
+    {
+        let mut guard = log_capture().lock().expect("log capture lock poisoned");
+        *guard = previous;
+    }
+    result
 }
 
 fn capture_line(kind: LogKind, message: String) -> bool {
-    LOG_CAPTURE.with(|capture| {
-        let mut capture = capture.borrow_mut();
-        match capture.as_mut() {
-            Some(emit) => {
-                emit(CapturedLog { kind, message });
-                true
-            }
-            None => false,
+    let mut guard = log_capture().lock().expect("log capture lock poisoned");
+    match guard.as_mut() {
+        Some(emit) => {
+            emit(CapturedLog { kind, message });
+            true
         }
-    })
+        None => false,
+    }
 }
 
 pub fn is_capturing() -> bool {
-    LOG_CAPTURE.with(|capture| capture.borrow().is_some())
+    log_capture()
+        .lock()
+        .map(|guard| guard.is_some())
+        .unwrap_or(false)
 }
 
 pub fn plain(message: impl AsRef<str>) {


### PR DESCRIPTION
Both the resolver and installer now run their per-dependency work in parallel via rayon::par_iter, so N module clones, N plugin asset downloads, and N module exports proceed concurrently instead of serially.

Supporting changes:
- git::clone_or_fetch takes a per-URL mutex so concurrent callers for the same repo serialize rather than corrupting the on-disk cache.
- ui::LOG_CAPTURE moved from thread_local to a global Mutex so the TUI captures log lines emitted from rayon worker threads.
- Added a global mutex around the cargo-fallback stdin prompt and an AtomicU64 counter for staging dir names so concurrent installs can't collide on a nanosecond timestamp.

Closes #27 